### PR TITLE
updated logic for new bumps version

### DIFF
--- a/notebooks/sasmodels-basic.ipynb
+++ b/notebooks/sasmodels-basic.ipynb
@@ -6,17 +6,7 @@
    "id": "cfd27b3d-a2c5-48f5-a37a-bdb5b7d938af",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from sasmodels.core import load_model\n",
-    "from sasmodels.bumps_model import Model, Experiment\n",
-    "from sasdata.dataloader.loader import Loader\n",
-    "\n",
-    "from bumps.names import *\n",
-    "from bumps.fitters import fit\n",
-    "from bumps.formatnum import format_uncertainty\n",
-    "\n",
-    "import plotly.graph_objects as go"
-   ]
+   "source": "from sasmodels.core import load_model\nfrom sasmodels.bumps_model import Model, Experiment\nfrom sasdata.dataloader.loader import Loader\n\nfrom bumps.names import *\nfrom bumps.fitters import fit\n\ntry:  # bumps >= 1.0.4\n    from bumps.util import format_uncertainty\nexcept ImportError:  # bumps <= 1.0.3\n    from bumps.formatnum import format_uncertainty\n\nimport plotly.graph_objects as go"
   },
   {
    "cell_type": "code",

--- a/src/sans_fitter/fitting/bumps_engine.py
+++ b/src/sans_fitter/fitting/bumps_engine.py
@@ -2,7 +2,11 @@ from typing import Any
 
 import numpy as np
 from bumps.fitters import fit as bumps_fit
-from bumps.formatnum import format_uncertainty
+
+try:  # bumps >= 1.0.4
+    from bumps.util import format_uncertainty
+except ImportError:  # bumps <= 1.0.3
+    from bumps.formatnum import format_uncertainty
 from bumps.names import FitProblem
 from sasmodels.bumps_model import Experiment
 from sasmodels.bumps_model import Model as BumpsModel


### PR DESCRIPTION
This pull request improves compatibility with different versions of the `bumps` library by updating import statements to handle changes in where `format_uncertainty` is located. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with multiple versions of the BUMPS library.
  * Updated uncertainty formatting imports so fitting workflows continue working when library locations differ.
  * Updated the basic SAS modeling notebook with the same compatibility support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->