### PR TITLE
added Q range restrictions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A flexible, model-agnostic Python template for fitting Small-Angle Neutron Scatt
 - **Model-Agnostic Design**: Works with any model from the SasModels library (cylinder, sphere, core_shell, etc.)
 - **Multiple Fitting Engines**: Supports both BUMPS (default) and LMFit optimization engines
 - **Flexible Data Loading**: Reads CSV, XML, and HDF5 formats via sasdata
+- **Q-Range Restriction**: Fit only a chosen [qmin, qmax] window (e.g. trim beam-stop or background-dominated points)
 - **User-Friendly Parameter Management**: Easy-to-use interface for setting parameter values, bounds, and fitting flags
 - **Interactive Visualization**: Automatic plotting of data, fitted model, and residuals with Plotly
 - **Result Export**: Save fitted parameters and curves to CSV files
@@ -64,6 +65,9 @@ fitter.load_data('my_sans_data.csv')
 
 # Set the model (any model from SasModels!)
 fitter.set_model('cylinder')
+
+# Optionally restrict the Q range used for fitting
+fitter.set_q_range(qmin=0.01, qmax=0.3)
 
 # View initial parameter values
 fitter.get_params()

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,6 +10,9 @@ The main class for SANS data fitting.
       show_source: true
       members:
         - load_data
+        - set_q_range
+        - reset_q_range
+        - get_q_range
         - set_model
         - set_structure_factor
         - get_params

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,6 +101,30 @@ columns were detected.
 
 ## Advanced Usage
 
+### Restricting the Q Range
+
+Real datasets often contain points you do not want to fit: beam-stop
+spillover at low Q or background-dominated points at high Q. Use
+`set_q_range` to restrict the fit without editing the data file.
+
+```python
+# Fit only points with 0.01 <= Q <= 0.3 Å⁻¹
+fitter.set_q_range(qmin=0.01, qmax=0.3)
+
+# Either bound may be given alone; the other resets to the full range
+fitter.set_q_range(qmax=0.3)
+
+# Inspect and restore
+fitter.get_q_range()    # -> (qmin, qmax)
+fitter.reset_q_range()  # back to the full data range
+```
+
+The restriction applies to both fitting engines. Excluded points still
+appear in plots (grayed out, labelled "Excluded Data"), but the fitted
+curve, residuals, χ², and the CSV export only cover the fitted range.
+The range can be changed freely between fits — each fit result remembers
+the range it was fitted with.
+
 ### Structure Factors
 
 You can combine a form factor with a structure factor to model interacting systems.

--- a/notebooks/sans_fitter_demo.ipynb
+++ b/notebooks/sans_fitter_demo.ipynb
@@ -286,28 +286,7 @@
    "cell_type": "markdown",
    "id": "580bca6c",
    "metadata": {},
-   "source": [
-    "## Summary\n",
-    "\n",
-    "The `SANSFitter` class provides:\n",
-    "\n",
-    "✓ **Model-agnostic design** - Works with any SasModels model\n",
-    "\n",
-    "✓ **Multiple fitting engines** - BUMPS (default) and LMFit support\n",
-    "\n",
-    "✓ **User-friendly parameter management** - Easy to configure and view parameters\n",
-    "\n",
-    "✓ **Flexible data loading** - Supports CSV, XML, HDF5 via sasdata\n",
-    "\n",
-    "✓ **Comprehensive visualization** - Automatic plotting with residuals\n",
-    "\n",
-    "✓ **Result export** - Save fitted curves and parameters to file\n",
-    "\n",
-    "✓ **Polydispersity support** - Apply size distributions to model parameters\n",
-    "  - Multiple distribution types: gaussian, lognormal, schulz, rectangle, boltzmann\n",
-    "  - Easy to enable/disable globally\n",
-    "  - Configure independently for each polydisperse parameter"
-   ]
+   "source": "## Summary\n\nThe `SANSFitter` class provides:\n\n✓ **Model-agnostic design** - Works with any SasModels model\n\n✓ **Multiple fitting engines** - BUMPS (default) and LMFit support\n\n✓ **User-friendly parameter management** - Easy to configure and view parameters\n\n✓ **Flexible data loading** - Supports CSV, XML, HDF5 via sasdata\n\n✓ **Q-range restriction** - Fit only a chosen [qmin, qmax] window; excluded points stay visible in plots\n\n✓ **Comprehensive visualization** - Automatic plotting with residuals\n\n✓ **Result export** - Save fitted curves and parameters to file\n\n✓ **Polydispersity support** - Apply size distributions to model parameters\n  - Multiple distribution types: gaussian, lognormal, schulz, rectangle, boltzmann\n  - Easy to enable/disable globally\n  - Configure independently for each polydisperse parameter"
   },
   {
    "cell_type": "markdown",
@@ -495,6 +474,36 @@
     "# Plot cylinder fit with polydispersity\n",
     "fitter_cyl_pd.plot_results(show_residuals=True, log_scale=True)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2ad47ed",
+   "source": "## 14. Restricting the Q Range\n\nReal datasets often contain points you do not want to fit:\n- **Low Q**: beam-stop spillover or parasitic scattering\n- **High Q**: points dominated by incoherent background\n\n`set_q_range(qmin, qmax)` restricts the fit to a Q window without editing the data file:\n- Both fitting engines only see points inside the window (χ² included)\n- Excluded points remain visible in plots, grayed out as \"Excluded Data\"\n- The CSV export covers only the fitted range and records the window in its header\n- `get_q_range()` / `reset_q_range()` inspect and restore the range",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "b6fe2854",
+   "source": "# Create a fitter and restrict the Q range before fitting\nfitter_qr = SANSFitter()\nfitter_qr.load_data('../simulated_sans_data.csv')\nfitter_qr.set_model('sphere')\n\nfitter_qr.set_param('radius', value=20, min=5, max=100, vary=True)\nfitter_qr.set_param('scale', value=0.1, min=0, max=1, vary=True)\nfitter_qr.set_param('background', value=0.01, min=0, max=1, vary=True)\nfitter_qr.set_param('sld', value=2.0, vary=False)\nfitter_qr.set_param('sld_solvent', value=3.0, vary=False)\n\n# Fit only 0.01 <= Q <= 0.4 Å⁻¹ (trim low-Q spillover and high-Q background)\nfitter_qr.set_q_range(qmin=0.01, qmax=0.4)\n\nresult_qr = fitter_qr.fit(engine='bumps', method='amoeba')",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "f982bb34",
+   "source": "# Plot: the fitted curve and residuals span only the fitted window;\n# points outside [0.01, 0.4] are shown grayed out as \"Excluded Data\"\nfitter_qr.plot_results(show_residuals=True, log_scale=True)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "c5897afe",
+   "source": "# Inspect the active range, then restore the full range and refit for comparison\nprint(f\"Current Q range: {fitter_qr.get_q_range()}\")\n\nfitter_qr.reset_q_range()\nresult_full = fitter_qr.fit(engine='bumps', method='amoeba')\n\nprint(f\"\\nχ² restricted range: {result_qr['chisq']:.4f}\")\nprint(f\"χ² full range:       {result_full['chisq']:.4f}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/src/sans_fitter/data_loader.py
+++ b/src/sans_fitter/data_loader.py
@@ -15,6 +15,21 @@ def _has_real_data(arr) -> bool:
     return bool(np.any(np.nan_to_num(np.asarray(arr, dtype=float)) != 0))
 
 
+def get_fit_index(data: Any) -> np.ndarray:
+    """Return the boolean index of points included in the fit.
+
+    Mirrors how sasmodels interprets 1D data: a point is fitted when it lies
+    inside [qmin, qmax], is not masked, and has a finite intensity.
+    """
+    x = np.asarray(data.x)
+    index = (x >= data.qmin) & (x <= data.qmax)
+    mask = getattr(data, 'mask', None)
+    if mask is not None:
+        index &= ~np.asarray(mask, dtype=bool)
+    index &= ~np.isnan(np.asarray(data.y))
+    return index
+
+
 def load_sans_data(filename: str) -> Any:
     """Load SANS data and normalize required fields for downstream fitting."""
     loader = Loader()

--- a/src/sans_fitter/fitting/base.py
+++ b/src/sans_fitter/fitting/base.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Optional, Protocol
+
+import numpy as np
 
 from ..contracts import ParameterStateSnapshot
 from ..results import FitResultContract
@@ -8,6 +10,19 @@ from ..results import FitResultContract
 def pd_is_active(pd_config: dict[str, Any]) -> bool:
     """Return whether a PD configuration should be included in model evaluation."""
     return pd_config['pd'] > 0 or pd_config.get('vary', False)
+
+
+def extract_fit_index(source: Any) -> Optional[np.ndarray]:
+    """Return the boolean fit index from a sasmodels calculator/experiment.
+
+    sasmodels stores the points it actually evaluates (inside [qmin, qmax],
+    unmasked, finite) as ``source.index``. Returns None when unavailable so
+    consumers fall back to treating the curve as full-length.
+    """
+    index = getattr(source, 'index', None)
+    if index is None or isinstance(index, slice):
+        return None
+    return np.asarray(index, dtype=bool)
 
 
 def link_radius_effective_model(model: Any, radius_effective_mode: str) -> None:

--- a/src/sans_fitter/fitting/bumps_engine.py
+++ b/src/sans_fitter/fitting/bumps_engine.py
@@ -13,7 +13,7 @@ from sasmodels.bumps_model import Model as BumpsModel
 
 from ..contracts import ParameterStateSnapshot
 from ..results import FitArtifacts, FitResultContract
-from .base import EngineFitOutput, link_radius_effective_model, pd_is_active
+from .base import EngineFitOutput, extract_fit_index, link_radius_effective_model, pd_is_active
 
 
 def fit_bumps(
@@ -75,6 +75,7 @@ def fit_bumps(
         parameters=result_parameters,
         artifacts=FitArtifacts(
             fitted_curve=np.asarray(problem.fitness.theory()),
+            fit_index=extract_fit_index(experiment),
             raw_result=result,
             runtime_handle=problem,
             runtime_key='problem',

--- a/src/sans_fitter/fitting/scipy_engine.py
+++ b/src/sans_fitter/fitting/scipy_engine.py
@@ -6,7 +6,7 @@ from sasmodels.direct_model import DirectModel
 
 from ..contracts import ParameterStateSnapshot
 from ..results import FitArtifacts, FitResultContract
-from .base import EngineFitOutput, link_radius_effective_dict, pd_is_active
+from .base import EngineFitOutput, extract_fit_index, link_radius_effective_dict, pd_is_active
 
 try:
     from scipy.optimize import differential_evolution, least_squares, leastsq
@@ -43,6 +43,10 @@ def fit_scipy(
     bounds_lower = np.array(bounds_lower_list)
     bounds_upper = np.array(bounds_upper_list)
     calculator = DirectModel(data, kernel)
+    # sasmodels evaluates the theory only at the fitted points (inside
+    # [qmin, qmax], unmasked); compare against the matching data subset.
+    y_fit = np.asarray(calculator.Iq)
+    dy_fit = np.asarray(calculator.dIq)
 
     def build_parameter_dict(x: np.ndarray) -> dict[str, Any]:
         par_dict = {name: info['value'] for name, info in fit_state.params.items()}
@@ -66,7 +70,7 @@ def fit_scipy(
 
     def residual(x: np.ndarray) -> np.ndarray:
         i_calc = calculator(**build_parameter_dict(x))
-        return (data.y - i_calc) / data.dy
+        return (y_fit - i_calc) / dy_fit
 
     print(f'\nFitting with scipy.optimize (method: {method})...')
 
@@ -132,6 +136,7 @@ def fit_scipy(
         parameters=result_parameters,
         artifacts=FitArtifacts(
             fitted_curve=np.asarray(calculator(**build_parameter_dict(fitted_params))),
+            fit_index=extract_fit_index(calculator),
             raw_result=result,
         ),
     )

--- a/src/sans_fitter/plotting.py
+++ b/src/sans_fitter/plotting.py
@@ -1,8 +1,9 @@
+import numpy as np
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
 from .data_loader import _has_real_data
-from .results import FitResultContract
+from .results import FitResultContract, resolve_fit_index
 
 
 def _running_in_notebook() -> bool:
@@ -24,6 +25,11 @@ def _error_bars(arr) -> dict | None:
     if not _has_real_data(arr):
         return None
     return {'type': 'data', 'array': arr, 'visible': True}
+
+
+def _subset(arr, index):
+    """Slice an optional data column by a boolean index."""
+    return None if arr is None else np.asarray(arr)[index]
 
 
 def _resolve_show(show: bool | None) -> bool:
@@ -77,9 +83,20 @@ def plot_fit(
             fig.show()
         return fig
 
-    q = data.x
     i_fit = fit_result.require_fitted_curve()
-    residuals = (data.y - i_fit) / data.dy
+    index = resolve_fit_index(fit_result.artifacts.fit_index, len(data.x))
+    if len(i_fit) != int(index.sum()):
+        raise ValueError(
+            f'Fitted curve length ({len(i_fit)}) does not match the number of '
+            f'fitted points ({int(index.sum())}).'
+        )
+
+    q = _subset(data.x, index)
+    y = _subset(data.y, index)
+    dy = _subset(data.dy, index)
+    dx = _subset(data.dx, index)
+    residuals = (y - i_fit) / dy
+    excluded = ~index
 
     if show_residuals:
         fig = make_subplots(
@@ -93,15 +110,28 @@ def plot_fit(
         fig = go.Figure()
 
     data_trace = go.Scatter(
-        x=data.x,
-        y=data.y,
-        error_y=error_y,
-        error_x=error_x,
+        x=q,
+        y=y,
+        error_y=_error_bars(dy),
+        error_x=_error_bars(dx),
         mode='markers',
         name='Experimental Data',
         opacity=0.6,
         marker={'size': 6},
     )
+
+    excluded_trace = None
+    if excluded.any():
+        excluded_trace = go.Scatter(
+            x=_subset(data.x, excluded),
+            y=_subset(data.y, excluded),
+            error_y=_error_bars(_subset(data.dy, excluded)),
+            error_x=_error_bars(_subset(data.dx, excluded)),
+            mode='markers',
+            name='Excluded Data',
+            opacity=0.4,
+            marker={'size': 6, 'color': 'lightgray'},
+        )
 
     fit_trace = go.Scatter(
         x=q,
@@ -113,10 +143,12 @@ def plot_fit(
 
     if show_residuals:
         fig.add_trace(data_trace, row=1, col=1)
+        if excluded_trace is not None:
+            fig.add_trace(excluded_trace, row=1, col=1)
         fig.add_trace(fit_trace, row=1, col=1)
         fig.add_trace(
             go.Scatter(
-                x=data.x,
+                x=q,
                 y=residuals,
                 mode='markers',
                 name='Residuals',
@@ -144,6 +176,8 @@ def plot_fit(
         fig.update_xaxes(type='log' if log_scale else 'linear', row=1, col=1)
     else:
         fig.add_trace(data_trace)
+        if excluded_trace is not None:
+            fig.add_trace(excluded_trace)
         fig.add_trace(fit_trace)
         fig.update_xaxes(
             title_text='Q (Å⁻¹)',

--- a/src/sans_fitter/results.py
+++ b/src/sans_fitter/results.py
@@ -15,11 +15,27 @@ def _validate_export_lengths(**arrays: Any) -> None:
         raise ValueError(f'Cannot export fit results with mismatched array lengths: {mismatch}')
 
 
+def resolve_fit_index(fit_index: Any, n_points: int) -> np.ndarray:
+    """Normalize a stored fit index to a boolean array of length *n_points*.
+
+    A missing index (None) means every point was fitted.
+    """
+    if fit_index is None:
+        return np.ones(n_points, dtype=bool)
+    index = np.asarray(fit_index, dtype=bool)
+    if index.shape != (n_points,):
+        raise ValueError(
+            f'Fit index length ({index.size}) does not match the data length ({n_points}).'
+        )
+    return index
+
+
 @dataclass(slots=True)
 class FitArtifacts:
     """Engine-specific runtime data needed after fitting."""
 
     fitted_curve: Optional[np.ndarray] = None
+    fit_index: Optional[np.ndarray] = None
     raw_result: Any = None
     runtime_handle: Any = None
     runtime_key: Optional[str] = None
@@ -59,21 +75,31 @@ class FitResultContract:
         return self.artifacts.fitted_curve
 
     def save_csv(self, filename: str, model_name: str, data: Any) -> None:
-        """Save fit results, fitted curve, and residuals to CSV."""
+        """Save fit results, fitted curve, and residuals to CSV.
+
+        Only the points included in the fit (inside the Q range, unmasked)
+        are exported, so every row carries a fitted intensity and residual.
+        """
         fitted_curve = self.require_fitted_curve()
         has_dx = _has_real_data(data.dx)
 
+        index = resolve_fit_index(self.artifacts.fit_index, len(data.x))
+        x = np.asarray(data.x)[index]
+        y = np.asarray(data.y)[index]
+        dy = np.asarray(data.dy)[index]
+        dx = np.asarray(data.dx)[index] if has_dx else None
+
         arrays_to_validate = {
-            'x': data.x,
-            'y': data.y,
-            'dy': data.dy,
+            'x': x,
+            'y': y,
+            'dy': dy,
             'fitted_curve': fitted_curve,
         }
         if has_dx:
-            arrays_to_validate['dx'] = data.dx
+            arrays_to_validate['dx'] = dx
         _validate_export_lengths(**arrays_to_validate)
 
-        residuals = (data.y - fitted_curve) / data.dy
+        residuals = (y - fitted_curve) / dy
         _validate_export_lengths(residuals=residuals, **arrays_to_validate)
 
         with open(filename, 'w') as f:
@@ -82,6 +108,8 @@ class FitResultContract:
             f.write(f'# Engine: {self.engine}\n')
             f.write(f'# Method: {self.method}\n')
             f.write(f'# Chi-squared: {self.chisq:.6f}\n')
+            f.write(f'# Q range: {data.qmin:.6g} to {data.qmax:.6g}\n')
+            f.write(f'# Points fitted: {len(x)} of {len(index)}\n')
             f.write('#\n')
             f.write('# Fitted Parameters:\n')
             for name, info in self.parameters.items():
@@ -90,15 +118,11 @@ class FitResultContract:
 
             if has_dx:
                 f.write('Q,dQ,I_exp,dI_exp,I_fit,Residuals\n')
-                for q, dq, i_exp, di_exp, i_fit, res in zip(
-                    data.x, data.dx, data.y, data.dy, fitted_curve, residuals
-                ):
+                for q, dq, i_exp, di_exp, i_fit, res in zip(x, dx, y, dy, fitted_curve, residuals):
                     f.write(f'{q:.6e},{dq:.6e},{i_exp:.6e},{di_exp:.6e},{i_fit:.6e},{res:.6e}\n')
             else:
                 f.write('Q,I_exp,dI_exp,I_fit,Residuals\n')
-                for q, i_exp, di_exp, i_fit, res in zip(
-                    data.x, data.y, data.dy, fitted_curve, residuals
-                ):
+                for q, i_exp, di_exp, i_fit, res in zip(x, y, dy, fitted_curve, residuals):
                     f.write(f'{q:.6e},{i_exp:.6e},{di_exp:.6e},{i_fit:.6e},{res:.6e}\n')
 
 

--- a/src/sans_fitter/results.py
+++ b/src/sans_fitter/results.py
@@ -108,7 +108,7 @@ class FitResultContract:
             f.write(f'# Engine: {self.engine}\n')
             f.write(f'# Method: {self.method}\n')
             f.write(f'# Chi-squared: {self.chisq:.6f}\n')
-            f.write(f'# Q range: {data.qmin:.6g} to {data.qmax:.6g}\n')
+            f.write(f'# Q range: {x.min():.6g} to {x.max():.6g}\n')
             f.write(f'# Points fitted: {len(x)} of {len(index)}\n')
             f.write('#\n')
             f.write('# Fitted Parameters:\n')

--- a/src/sans_fitter/sans_fitter.py
+++ b/src/sans_fitter/sans_fitter.py
@@ -15,8 +15,9 @@ from sasmodels import core
 from sasmodels.core import load_model
 from sasmodels.direct_model import DirectModel
 
-from .data_loader import _has_real_data, load_sans_data
+from .data_loader import _has_real_data, get_fit_index, load_sans_data
 from .fitting import SCIPY_AVAILABLE, fit_bumps, fit_scipy
+from .fitting.base import extract_fit_index
 from .parameter_manager import ParameterManager
 from .plotting import plot_fit
 from .results import FitArtifacts, FitResultContract, save_fit_result
@@ -69,6 +70,7 @@ class SANSFitter:
         self.fit_result = None
         self._fit_contract: Optional[FitResultContract] = None
         self._fitted_model = None
+        self._full_q_range: Optional[tuple[float, float]] = None
 
         # Parameter management delegated to ParameterManager
         self._param_manager = ParameterManager()
@@ -91,6 +93,7 @@ class SANSFitter:
             ValueError: If the data cannot be loaded or is invalid
         """
         self.data = load_sans_data(filename)
+        self._full_q_range = (self.data.qmin, self.data.qmax)
 
         has_dy = _has_real_data(self.data.dy)
         has_dx = _has_real_data(self.data.dx)
@@ -100,6 +103,78 @@ class SANSFitter:
         print(f'  Data points: {len(self.data.x)}')
         print(f'  Error (dI) column: {"yes" if has_dy else "no"}')
         print(f'  Resolution (dQ) column: {"yes" if has_dx else "no"}')
+
+    def set_q_range(self, qmin: Optional[float] = None, qmax: Optional[float] = None) -> None:
+        """
+        Restrict the Q range used for fitting.
+
+        Data points outside [qmin, qmax] are excluded from the fit (and from
+        the exported fit curve/residuals) but remain visible in plots. Typical
+        uses: trimming beam-stop spillover at low Q or background-dominated
+        high-Q points.
+
+        Args:
+            qmin: Lower Q limit in Å⁻¹. If omitted, the current lower limit
+                is reset to the full data range.
+            qmax: Upper Q limit in Å⁻¹. If omitted, the current upper limit
+                is reset to the full data range.
+
+        Raises:
+            ValueError: If no data is loaded, if qmin >= qmax, or if no data
+                points remain in the requested range (the previous range is
+                kept in that case).
+        """
+        if self.data is None:
+            raise ValueError('No data loaded. Use load_data() first.')
+        if qmin is None and qmax is None:
+            raise ValueError('Provide qmin, qmax, or both.')
+
+        full_min, full_max = self._full_q_range
+        new_qmin = full_min if qmin is None else float(qmin)
+        new_qmax = full_max if qmax is None else float(qmax)
+        if new_qmin >= new_qmax:
+            raise ValueError(f'qmin ({new_qmin:g}) must be smaller than qmax ({new_qmax:g}).')
+
+        previous = (self.data.qmin, self.data.qmax)
+        self.data.qmin = new_qmin
+        self.data.qmax = new_qmax
+
+        index = get_fit_index(self.data)
+        n_points = int(index.sum())
+        if n_points == 0:
+            self.data.qmin, self.data.qmax = previous
+            raise ValueError(
+                f'No data points in Q range [{new_qmin:g}, {new_qmax:g}]. Range unchanged.'
+            )
+
+        print(f'✓ Q range for fitting: {new_qmin:.6g} to {new_qmax:.6g} Å⁻¹')
+        print(f'  Points in fit: {n_points} of {len(index)}')
+
+    def reset_q_range(self) -> None:
+        """
+        Reset the fitting Q range to the full range of the loaded data.
+
+        Raises:
+            ValueError: If no data is loaded.
+        """
+        if self.data is None:
+            raise ValueError('No data loaded. Use load_data() first.')
+
+        self.data.qmin, self.data.qmax = self._full_q_range
+        n_points = int(get_fit_index(self.data).sum())
+        print(f'✓ Q range reset to {self.data.qmin:.6g} to {self.data.qmax:.6g} Å⁻¹')
+        print(f'  Points in fit: {n_points}')
+
+    def get_q_range(self) -> Optional[tuple[float, float]]:
+        """
+        Get the Q range currently used for fitting.
+
+        Returns:
+            Tuple (qmin, qmax) in Å⁻¹, or None if no data is loaded.
+        """
+        if self.data is None:
+            return None
+        return (self.data.qmin, self.data.qmax)
 
     def set_model(self, model_name: str, platform: str = 'cpu') -> None:
         """
@@ -414,7 +489,8 @@ class SANSFitter:
                 chisq=self.fit_result['chisq'],
                 parameters=self.fit_result['parameters'],
                 artifacts=FitArtifacts(
-                    fitted_curve=np.asarray(self._fitted_model.fitness.theory())
+                    fitted_curve=np.asarray(self._fitted_model.fitness.theory()),
+                    fit_index=extract_fit_index(self._fitted_model.fitness),
                 ),
             )
 
@@ -425,7 +501,10 @@ class SANSFitter:
             method=self.fit_result['method'],
             chisq=self.fit_result['chisq'],
             parameters=self.fit_result['parameters'],
-            artifacts=FitArtifacts(fitted_curve=np.asarray(calculator(**par_dict))),
+            artifacts=FitArtifacts(
+                fitted_curve=np.asarray(calculator(**par_dict)),
+                fit_index=extract_fit_index(calculator),
+            ),
         )
 
     def fit(

--- a/tests/test_q_range.py
+++ b/tests/test_q_range.py
@@ -157,9 +157,7 @@ class TestQRangePostFit(QRangeTestCase):
             header = ''.join(lines)
             q = np.asarray(self.fitter.data.x)
             fitted_q = q[(q >= 0.02) & (q <= 0.5)]
-            self.assertIn(
-                f'# Q range: {fitted_q.min():.6g} to {fitted_q.max():.6g}', header
-            )
+            self.assertIn(f'# Q range: {fitted_q.min():.6g} to {fitted_q.max():.6g}', header)
             self.assertIn(
                 f'# Points fitted: {self.expected_points} of {len(self.fitter.data.x)}',
                 header,
@@ -180,9 +178,7 @@ class TestQRangePostFit(QRangeTestCase):
 
             q = np.asarray(self.fitter.data.x)
             fitted_q = q[(q >= 0.02) & (q <= 0.5)]
-            self.assertIn(
-                f'# Q range: {fitted_q.min():.6g} to {fitted_q.max():.6g}', header
-            )
+            self.assertIn(f'# Q range: {fitted_q.min():.6g} to {fitted_q.max():.6g}', header)
             self.assertIn(
                 f'# Points fitted: {self.expected_points} of {len(q)}',
                 header,

--- a/tests/test_q_range.py
+++ b/tests/test_q_range.py
@@ -155,9 +155,36 @@ class TestQRangePostFit(QRangeTestCase):
             ]
             self.assertEqual(len(data_rows), self.expected_points)
             header = ''.join(lines)
-            self.assertIn('# Q range: 0.02 to 0.5', header)
+            q = np.asarray(self.fitter.data.x)
+            fitted_q = q[(q >= 0.02) & (q <= 0.5)]
+            self.assertIn(
+                f'# Q range: {fitted_q.min():.6g} to {fitted_q.max():.6g}', header
+            )
             self.assertIn(
                 f'# Points fitted: {self.expected_points} of {len(self.fitter.data.x)}',
+                header,
+            )
+        finally:
+            if os.path.exists(output_file):
+                os.unlink(output_file)
+
+    def test_save_results_header_unaffected_by_post_fit_range_change(self):
+        """The saved Q range reflects the fit, not a later set_q_range()."""
+        output_file = self.data_file + '.results.csv'
+        try:
+            self.fitter.set_q_range(qmin=0.1, qmax=0.3)
+            self.fitter.save_results(output_file)
+
+            with open(output_file) as f:
+                header = f.read()
+
+            q = np.asarray(self.fitter.data.x)
+            fitted_q = q[(q >= 0.02) & (q <= 0.5)]
+            self.assertIn(
+                f'# Q range: {fitted_q.min():.6g} to {fitted_q.max():.6g}', header
+            )
+            self.assertIn(
+                f'# Points fitted: {self.expected_points} of {len(q)}',
                 header,
             )
         finally:

--- a/tests/test_q_range.py
+++ b/tests/test_q_range.py
@@ -1,0 +1,169 @@
+import os
+import unittest
+
+import numpy as np
+
+from sans_fitter import SANSFitter
+from sans_fitter.data_loader import get_fit_index
+from tests.helpers import create_decay_data_file
+
+
+class QRangeTestCase(unittest.TestCase):
+    """Base fixture: loaded decay data with a configured sphere model."""
+
+    def setUp(self):
+        self.fitter = SANSFitter()
+        self.data_file = create_decay_data_file()
+        self.fitter.load_data(self.data_file)
+        self.fitter.set_model('sphere')
+        self.fitter.set_param('radius', value=20.0, min=10.0, max=30.0, vary=True)
+        self.fitter.set_param('scale', value=0.1, min=0.01, max=1.0, vary=True)
+        self.fitter.set_param('background', value=0.01, min=0, max=0.1, vary=True)
+        self.fitter.set_param('sld', value=2.0, vary=False)
+        self.fitter.set_param('sld_solvent', value=3.0, vary=False)
+
+    def tearDown(self):
+        if os.path.exists(self.data_file):
+            os.unlink(self.data_file)
+
+    def points_in_range(self, qmin, qmax):
+        q = np.asarray(self.fitter.data.x)
+        return int(((q >= qmin) & (q <= qmax)).sum())
+
+
+class TestQRangeConfiguration(QRangeTestCase):
+    """Test set_q_range / get_q_range / reset_q_range state handling."""
+
+    def test_set_q_range_without_data_raises_error(self):
+        fitter = SANSFitter()
+        with self.assertRaises(ValueError):
+            fitter.set_q_range(0.01, 0.1)
+
+    def test_set_q_range_without_arguments_raises_error(self):
+        with self.assertRaises(ValueError):
+            self.fitter.set_q_range()
+
+    def test_set_q_range_inverted_bounds_raises_error(self):
+        with self.assertRaises(ValueError):
+            self.fitter.set_q_range(qmin=0.5, qmax=0.1)
+
+    def test_set_q_range_updates_data_limits(self):
+        self.fitter.set_q_range(qmin=0.02, qmax=0.5)
+        self.assertEqual(self.fitter.get_q_range(), (0.02, 0.5))
+
+    def test_set_q_range_partial_qmin_only(self):
+        full_min, full_max = self.fitter.get_q_range()
+        self.fitter.set_q_range(qmin=0.05)
+        self.assertEqual(self.fitter.get_q_range(), (0.05, full_max))
+
+    def test_set_q_range_partial_qmax_only(self):
+        full_min, full_max = self.fitter.get_q_range()
+        self.fitter.set_q_range(qmax=0.5)
+        self.assertEqual(self.fitter.get_q_range(), (full_min, 0.5))
+
+    def test_set_q_range_empty_range_raises_and_keeps_previous(self):
+        previous = self.fitter.get_q_range()
+        with self.assertRaises(ValueError):
+            self.fitter.set_q_range(qmin=2.0, qmax=3.0)
+        self.assertEqual(self.fitter.get_q_range(), previous)
+
+    def test_reset_q_range_restores_full_range(self):
+        full_range = self.fitter.get_q_range()
+        self.fitter.set_q_range(qmin=0.05, qmax=0.5)
+        self.fitter.reset_q_range()
+        self.assertEqual(self.fitter.get_q_range(), full_range)
+
+    def test_get_q_range_without_data_returns_none(self):
+        self.assertIsNone(SANSFitter().get_q_range())
+
+    def test_get_fit_index_respects_q_range(self):
+        self.fitter.set_q_range(qmin=0.02, qmax=0.5)
+        index = get_fit_index(self.fitter.data)
+        self.assertEqual(int(index.sum()), self.points_in_range(0.02, 0.5))
+        self.assertLess(int(index.sum()), len(self.fitter.data.x))
+
+
+class TestQRangeFitting(QRangeTestCase):
+    """Test that both engines fit only the restricted range."""
+
+    def test_bumps_fit_uses_restricted_range(self):
+        self.fitter.set_q_range(qmin=0.02, qmax=0.5)
+        expected_points = self.points_in_range(0.02, 0.5)
+
+        result = self.fitter.fit(engine='bumps', method='amoeba')
+
+        self.assertIn('chisq', result)
+        contract = self.fitter._fit_contract
+        self.assertEqual(len(contract.artifacts.fitted_curve), expected_points)
+        self.assertEqual(int(contract.artifacts.fit_index.sum()), expected_points)
+
+    def test_scipy_fit_uses_restricted_range(self):
+        self.fitter.set_q_range(qmin=0.02, qmax=0.5)
+        expected_points = self.points_in_range(0.02, 0.5)
+
+        result = self.fitter.fit(engine='lmfit', method='leastsq')
+
+        self.assertIn('chisq', result)
+        contract = self.fitter._fit_contract
+        self.assertEqual(len(contract.artifacts.fitted_curve), expected_points)
+        self.assertEqual(int(contract.artifacts.fit_index.sum()), expected_points)
+
+    def test_full_range_fit_still_covers_all_points(self):
+        self.fitter.fit(engine='bumps', method='amoeba')
+        contract = self.fitter._fit_contract
+        self.assertEqual(len(contract.artifacts.fitted_curve), len(self.fitter.data.x))
+
+
+class TestQRangePostFit(QRangeTestCase):
+    """Test plotting and export with a restricted Q range."""
+
+    def setUp(self):
+        super().setUp()
+        self.fitter.set_q_range(qmin=0.02, qmax=0.5)
+        self.expected_points = self.points_in_range(0.02, 0.5)
+        self.fitter.fit(engine='bumps', method='amoeba')
+
+    def test_plot_results_with_restricted_range(self):
+        fig = self.fitter.plot_results(show_residuals=True, show=False)
+
+        traces = {trace.name: trace for trace in fig.data}
+        self.assertIn('Experimental Data', traces)
+        self.assertIn('Excluded Data', traces)
+        self.assertIn('Fitted Model', traces)
+        self.assertEqual(len(traces['Experimental Data'].x), self.expected_points)
+        self.assertEqual(len(traces['Fitted Model'].x), self.expected_points)
+        n_excluded = len(self.fitter.data.x) - self.expected_points
+        self.assertEqual(len(traces['Excluded Data'].x), n_excluded)
+
+    def test_plot_results_without_excluded_points_has_no_excluded_trace(self):
+        self.fitter.reset_q_range()
+        self.fitter.fit(engine='bumps', method='amoeba')
+        fig = self.fitter.plot_results(show=False)
+        trace_names = [trace.name for trace in fig.data]
+        self.assertNotIn('Excluded Data', trace_names)
+
+    def test_save_results_with_restricted_range(self):
+        output_file = self.data_file + '.results.csv'
+        try:
+            self.fitter.save_results(output_file)
+
+            with open(output_file) as f:
+                lines = f.readlines()
+
+            data_rows = [
+                line for line in lines if not line.startswith('#') and not line.startswith('Q,')
+            ]
+            self.assertEqual(len(data_rows), self.expected_points)
+            header = ''.join(lines)
+            self.assertIn('# Q range: 0.02 to 0.5', header)
+            self.assertIn(
+                f'# Points fitted: {self.expected_points} of {len(self.fitter.data.x)}',
+                header,
+            )
+        finally:
+            if os.path.exists(output_file):
+                os.unlink(output_file)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Q-Range Restriction Feature:**

* Added new methods `set_q_range`, `get_q_range`, and `reset_q_range` to the main API, allowing users to specify, inspect, and restore the Q range for fitting.
* Updated both fitting engines (BUMPS and Scipy) to fit only data points within the specified Q range, using a new `fit_index` mechanism to track included points. 

**Visualization and Export:**

* Enhanced plotting to show excluded data points in gray ("Excluded Data") and ensure fitted curves and residuals are computed only for the included range. 
* Modified CSV export to include only fitted points and to record the Q range and count of fitted points in the file header. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added controls to restrict fitting to a selected Q range, including partial bounds.
  - Added methods to view, reset, and manage the active fitting range.
  - Fit results, residuals, plots, and CSV exports now use only the restricted Q points while keeping out-of-range points visible as excluded.
  - Fit results retain the Q range used during fitting (and export reflects the fitted subset).
- **Documentation**
  - Updated README, API reference, usage guide, and demo notebook with Q-range examples and behavior.
- **Bug Fixes**
  - Improved plot alignment and residual calculations to match the evaluated fitted points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->