### PR TITLE
Dataset arithmetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A flexible, model-agnostic Python template for fitting Small-Angle Neutron Scatt
 - **Multiple Fitting Engines**: Supports both BUMPS (default) and LMFit optimization engines
 - **Flexible Data Loading**: Reads CSV, XML, and HDF5 formats via sasdata
 - **Q-Range Restriction**: Fit only a chosen [qmin, qmax] window (e.g. trim beam-stop or background-dominated points)
+- **Dataset Arithmetic**: Add, subtract, multiply, and divide datasets (or scale by constants) with propagated uncertainties via `data_ops` — e.g. background subtraction and transmission correction before fitting
 - **User-Friendly Parameter Management**: Easy-to-use interface for setting parameter values, bounds, and fitting flags
 - **Interactive Visualization**: Automatic plotting of data, fitted model, and residuals with Plotly
 - **Result Export**: Save fitted parameters and curves to CSV files

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,6 +10,7 @@ The main class for SANS data fitting.
       show_source: true
       members:
         - load_data
+        - set_data
         - set_q_range
         - reset_q_range
         - get_q_range
@@ -28,6 +29,23 @@ The main class for SANS data fitting.
         - is_polydispersity_enabled
         - get_pd_params
         - get_varying_pd_params
+
+## data_ops
+
+Dataset arithmetic: add, subtract, multiply and divide datasets (or a dataset
+and a scalar) with propagated uncertainties, returning fit-ready `Data1D`
+objects.
+
+::: sans_fitter.data_ops
+    options:
+      show_root_heading: true
+      show_source: true
+      members:
+        - load
+        - add
+        - subtract
+        - multiply
+        - divide
 
 ## ParameterManager
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -125,6 +125,67 @@ curve, residuals, χ², and the CSV export only cover the fitted range.
 The range can be changed freely between fits — each fit result remembers
 the range it was fitted with.
 
+### Dataset Operations
+
+The `sans_fitter.data_ops` module manipulates datasets with arithmetic
+operations — similar to SasView's *Data Operation* utility. Typical uses are
+background subtraction, rescaling to absolute units, and transmission
+correction.
+
+```python
+from sans_fitter import SANSFitter, data_ops
+
+sample = data_ops.load('sample.csv')          # standalone loader, returns Data1D
+background = data_ops.load('empty_cell.csv')
+
+net = data_ops.subtract(sample, background)   # sample − background
+net = data_ops.divide(net, 0.8)               # transmission correction
+
+fitter = SANSFitter()
+fitter.set_data(net)                          # inject the in-memory dataset
+fitter.set_model('sphere')
+fitter.fit()
+```
+
+Available operations — each returns a new, fit-ready `Data1D`:
+
+| Function | Result |
+|---|---|
+| `data_ops.add(a, b)` | `a + b` |
+| `data_ops.subtract(a, b)` | `a − b` (order matters) |
+| `data_ops.multiply(a, b)` | `a × b` |
+| `data_ops.divide(a, b)` | `a / b` (order matters) |
+
+The second operand can be a dataset or a scalar. For two datasets,
+uncertainties are propagated (`dI = sqrt(dI_a² + dI_b²)` for add/subtract,
+relative errors in quadrature for multiply/divide) and both must share the
+same Q grid (x-values matching within 1% — interpolation onto a common grid
+is not yet supported). For a scalar, `multiply`/`divide` scale both `I` and
+`dI`, while `add`/`subtract` shift `I` and leave `dI` unchanged; the Q grid
+is never altered.
+
+Every result records its provenance: the title becomes the operation (e.g.
+`"sample.csv - empty_cell.csv"`) and a `Process` entry is appended, which
+survives in saved CanSAS output.
+
+Things to know:
+
+- **Missing dI** on an operand triggers a warning — it is treated as zero in
+  error propagation. Error-free data warns again at fit time: the `lmfit`
+  engine falls back to unit weights, while `bumps` refuses to fit.
+- **NaN points** propagate through the arithmetic and are masked in the
+  result (excluded from fits); a warning reports the masked count.
+- **Resolution (dQ) propagation** through arithmetic is not validated
+  upstream — a warning is emitted when any operand carries resolution data.
+  Treat resolution on results with care, especially for slit-smeared data.
+
+`SANSFitter.set_data()` accepts any sasdata `Data1D` — arithmetic results,
+simulated data, or datasets built programmatically — and validates and
+normalizes it so it is fit-ready.
+
+See `examples/data_operations_example.py` and
+`notebooks/data_operations_demo.ipynb` for a complete walkthrough.
+
 ### Structure Factors
 
 You can combine a form factor with a structure factor to model interacting systems.

--- a/examples/data_operations_example.py
+++ b/examples/data_operations_example.py
@@ -1,0 +1,121 @@
+"""
+Example: Dataset arithmetic with sans_fitter.data_ops
+
+This script demonstrates how to:
+1. Simulate a "sample" measurement (sphere scattering + flat instrument
+   background) and a separate "background" measurement
+2. Load both files with data_ops.load()
+3. Subtract the background run and apply a transmission correction
+4. Feed the result into SANSFitter with set_data() and fit it
+5. Plot and save the results
+
+The arithmetic functions (add, subtract, multiply, divide) accept either two
+datasets on the same Q grid or a dataset and a scalar, and return a new,
+fit-ready Data1D with propagated uncertainties.
+"""
+
+import numpy as np
+from sasmodels.core import load_model
+from sasmodels.data import empty_data1D
+from sasmodels.direct_model import DirectModel
+
+from sans_fitter import SANSFitter, data_ops
+
+# ============================================================================
+# Part 1: Simulate the two measurements
+# ============================================================================
+
+print('=' * 80)
+print('Part 1: Simulating sample and background measurements')
+print('=' * 80)
+
+rng = np.random.default_rng(seed=42)
+q = np.logspace(np.log10(0.008), np.log10(0.35), 80)
+
+# Ideal sphere scattering (radius 60 Å) computed with sasmodels itself
+kernel = load_model('sphere', dtype='single', platform='dll')
+calculator = DirectModel(empty_data1D(q), kernel)
+i_sphere = calculator(radius=60.0, scale=0.005, background=0.0, sld=4.0, sld_solvent=1.0)
+
+BACKGROUND_LEVEL = 0.08  # flat instrument/solvent background
+TRANSMISSION = 0.8  # sample transmission factor
+
+# "Sample" run: sphere signal + background, with 3% counting noise
+i_sample = i_sphere + BACKGROUND_LEVEL
+di_sample = 0.03 * i_sample
+i_sample = i_sample + rng.normal(0.0, di_sample)
+
+# "Background" run: background only, with its own noise
+i_bkg = np.full_like(q, BACKGROUND_LEVEL)
+di_bkg = 0.03 * i_bkg
+i_bkg = i_bkg + rng.normal(0.0, di_bkg)
+
+for filename, intensity, error in [
+    ('example_sample.csv', i_sample, di_sample),
+    ('example_background.csv', i_bkg, di_bkg),
+]:
+    with open(filename, 'w') as f:
+        f.write('Q,I,dI\n')
+        for row in zip(q, intensity, error):
+            f.write(f'{row[0]},{row[1]},{row[2]}\n')
+    print(f'  wrote {filename}')
+
+# ============================================================================
+# Part 2: Load and combine the datasets
+# ============================================================================
+
+print('\n' + '=' * 80)
+print('Part 2: Background subtraction and transmission correction')
+print('=' * 80)
+
+# data_ops.load() is the standalone equivalent of SANSFitter.load_data():
+# it returns a fit-ready Data1D instead of storing it on a fitter.
+sample = data_ops.load('example_sample.csv')
+background = data_ops.load('example_background.csv')
+
+# subtract(a, b) returns a - b with dy = sqrt(dy_a^2 + dy_b^2).
+# Both datasets must share the same Q grid (within 1%); mismatched grids
+# raise a ValueError naming both datasets and their Q ranges.
+net = data_ops.subtract(sample, background)
+
+# Scalar operations work too: divide by the transmission to correct the
+# intensity scale (y and dy are divided, the Q grid is untouched).
+net = data_ops.divide(net, TRANSMISSION)
+
+print(f'\nResult title: {net.title}')
+print(f'Process history: {[p.description for p in net.process]}')
+
+# ============================================================================
+# Part 3: Fit the corrected dataset
+# ============================================================================
+
+print('\n' + '=' * 80)
+print('Part 3: Fitting the background-subtracted data')
+print('=' * 80)
+
+fitter = SANSFitter()
+fitter.set_data(net)  # injection point for in-memory datasets
+fitter.set_model('sphere')
+
+fitter.set_param('radius', value=40.0, min=10.0, max=150.0, vary=True)
+fitter.set_param('scale', value=0.001, min=1e-4, max=1.0, vary=True)
+fitter.set_param('background', value=0.001, min=0.0, max=1.0, vary=True)
+fitter.set_param('sld', value=4.0, vary=False)
+fitter.set_param('sld_solvent', value=1.0, vary=False)
+
+result = fitter.fit(engine='bumps', method='amoeba')
+
+print('\nGround truth vs fit:')
+print(f'  radius: 60.0 Å   -> fitted {result["parameters"]["radius"]["value"]:.1f} Å')
+print(f'  scale:  {0.005 / TRANSMISSION:.5f}  -> fitted {result["parameters"]["scale"]["value"]:.5f}')
+
+# ============================================================================
+# Part 4: Plot and save
+# ============================================================================
+
+print('\nGenerating plot...')
+fitter.plot_results(show_residuals=True, log_scale=True)
+
+fitter.save_results('background_subtracted_fit.csv')
+
+print('\n✓ Example completed successfully!')

--- a/notebooks/data_operations_demo.ipynb
+++ b/notebooks/data_operations_demo.ipynb
@@ -1,0 +1,291 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "aa3ca259",
+   "metadata": {},
+   "source": [
+    "# Dataset arithmetic with `sans_fitter.data_ops`\n",
+    "\n",
+    "This notebook shows how to combine SANS datasets with arithmetic operations,\n",
+    "similar to SasView's *Data Operation* utility, and fit the result:\n",
+    "\n",
+    "- `subtract(sample, background)` - empty-cell / solvent subtraction\n",
+    "- `multiply(data, k)` / `divide(data, k)` - rescaling (absolute units, transmission)\n",
+    "- `subtract(data, c)` - flat background subtraction\n",
+    "- `add(a, b)` - combining datasets\n",
+    "\n",
+    "All functions return a new, **fit-ready** `Data1D` with propagated uncertainties\n",
+    "(`dy = sqrt(dy_a² + dy_b²)` for addition/subtraction). The result is injected into a\n",
+    "fitter with `SANSFitter.set_data()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "327e33d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import plotly.graph_objects as go\n",
+    "\n",
+    "from sans_fitter import SANSFitter, data_ops"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e89de314",
+   "metadata": {},
+   "source": [
+    "## 1. Simulate a sample and a background measurement\n",
+    "\n",
+    "We simulate two \"measurements\" on the same Q grid and save them as CSV files:\n",
+    "\n",
+    "- **sample**: sphere scattering (radius 60 Å) on top of a flat instrument background\n",
+    "- **background**: the flat background alone\n",
+    "\n",
+    "Each gets 3% counting noise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5418338",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sasmodels.core import load_model\n",
+    "from sasmodels.data import empty_data1D\n",
+    "from sasmodels.direct_model import DirectModel\n",
+    "\n",
+    "rng = np.random.default_rng(seed=42)\n",
+    "q = np.logspace(np.log10(0.008), np.log10(0.35), 80)\n",
+    "\n",
+    "kernel = load_model('sphere', dtype='single', platform='dll')\n",
+    "calculator = DirectModel(empty_data1D(q), kernel)\n",
+    "i_sphere = calculator(radius=60.0, scale=0.005, background=0.0, sld=4.0, sld_solvent=1.0)\n",
+    "\n",
+    "BACKGROUND_LEVEL = 0.08   # flat instrument/solvent background\n",
+    "TRANSMISSION = 0.8        # sample transmission factor\n",
+    "\n",
+    "i_sample = i_sphere + BACKGROUND_LEVEL\n",
+    "di_sample = 0.03 * i_sample\n",
+    "i_sample = i_sample + rng.normal(0.0, di_sample)\n",
+    "\n",
+    "i_bkg = np.full_like(q, BACKGROUND_LEVEL)\n",
+    "di_bkg = 0.03 * i_bkg\n",
+    "i_bkg = i_bkg + rng.normal(0.0, di_bkg)\n",
+    "\n",
+    "for filename, intensity, error in [\n",
+    "    ('example_sample.csv', i_sample, di_sample),\n",
+    "    ('example_background.csv', i_bkg, di_bkg),\n",
+    "]:\n",
+    "    with open(filename, 'w') as f:\n",
+    "        f.write('Q,I,dI\\n')\n",
+    "        for row in zip(q, intensity, error):\n",
+    "            f.write(f'{row[0]},{row[1]},{row[2]}\\n')\n",
+    "    print(f'wrote {filename}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06303eb3",
+   "metadata": {},
+   "source": [
+    "## 2. Load the datasets\n",
+    "\n",
+    "`data_ops.load()` is the standalone equivalent of `SANSFitter.load_data()`: it returns a\n",
+    "fit-ready `Data1D` instead of storing it on a fitter, so you can manipulate it first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74e97f81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample = data_ops.load('example_sample.csv')\n",
+    "background = data_ops.load('example_background.csv')\n",
+    "\n",
+    "print(f'sample:     {len(sample.x)} points, Q = [{sample.x.min():.4g}, {sample.x.max():.4g}]')\n",
+    "print(f'background: {len(background.x)} points, Q = [{background.x.min():.4g}, {background.x.max():.4g}]')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7c278eb",
+   "metadata": {},
+   "source": [
+    "## 3. Subtract the background and correct for transmission\n",
+    "\n",
+    "`subtract(a, b)` returns `a − b` (order matters). Uncertainties are combined in\n",
+    "quadrature.\n",
+    "Scalar operations (`divide(net, 0.8)`) scale `y` and `dy` and d not modify the Q grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a4d4c41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "net = data_ops.subtract(sample, background)\n",
+    "net = data_ops.divide(net, TRANSMISSION)\n",
+    "\n",
+    "print(f'title: {net.title}')\n",
+    "for p in net.process:\n",
+    "    print(f'process: {p.description}')\n",
+    "\n",
+    "# error propagation: dy_net = sqrt(dy_sample² + dy_bkg²) / transmission\n",
+    "expected = np.sqrt(sample.dy**2 + background.dy**2) / TRANSMISSION\n",
+    "print('dy propagated correctly:', np.allclose(net.dy, expected))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "121e3a3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = go.Figure()\n",
+    "fig.add_trace(go.Scatter(x=sample.x, y=sample.y, mode='markers', name='sample',\n",
+    "                         error_y={'type': 'data', 'array': sample.dy, 'visible': True}))\n",
+    "fig.add_trace(go.Scatter(x=background.x, y=background.y, mode='markers', name='background',\n",
+    "                         error_y={'type': 'data', 'array': background.dy, 'visible': True}))\n",
+    "fig.add_trace(go.Scatter(x=net.x, y=net.y, mode='markers', name='(sample − background) / T',\n",
+    "                         error_y={'type': 'data', 'array': net.dy, 'visible': True}))\n",
+    "fig.update_layout(xaxis={'type': 'log', 'title': 'Q (Å⁻¹)'},\n",
+    "                  yaxis={'type': 'log', 'title': 'I(Q) (cm⁻¹)'},\n",
+    "                  title='Background subtraction', template='plotly_white')\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eef60f53",
+   "metadata": {},
+   "source": [
+    "## 4. Fit the corrected dataset\n",
+    "\n",
+    "`SANSFitter.set_data()` accepts any in-memory `Data1D` (arithmetic results,\n",
+    "simulated data, etc.) validates it and makes it fit-ready."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe92441a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fitter = SANSFitter()\n",
+    "fitter.set_data(net)\n",
+    "fitter.set_model('sphere')\n",
+    "\n",
+    "fitter.set_param('radius', value=40.0, min=10.0, max=150.0, vary=True)\n",
+    "fitter.set_param('scale', value=0.001, min=1e-4, max=1.0, vary=True)\n",
+    "fitter.set_param('background', value=0.001, min=0.0, max=1.0, vary=True)\n",
+    "fitter.set_param('sld', value=4.0, vary=False)\n",
+    "fitter.set_param('sld_solvent', value=1.0, vary=False)\n",
+    "\n",
+    "result = fitter.fit(engine='bumps', method='amoeba')\n",
+    "\n",
+    "print('\\nGround truth vs fit:')\n",
+    "print(f'  radius: 60.0 Å  -> fitted {result[\"parameters\"][\"radius\"][\"value\"]:.1f} Å')\n",
+    "print(f'  scale:  {0.005 / TRANSMISSION:.5f} -> fitted {result[\"parameters\"][\"scale\"][\"value\"]:.5f}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92411c17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fitter.plot_results(show_residuals=True, log_scale=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ebc5d3fd",
+   "metadata": {},
+   "source": [
+    "## 5. Things to know\n",
+    "\n",
+    "**Mismatched Q grids are rejected.** Both datasets must share the same Q grid\n",
+    "(x-values matching within 1%). Interpolation onto a common grid is not yet supported.\n",
+    "You need to rebin first. The error names both datasets and their Q ranges:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4653be28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sasdata.dataloader.data_info import Data1D\n",
+    "\n",
+    "other_grid = Data1D(x=q * 1.5, y=np.ones_like(q), dy=np.full_like(q, 0.1))\n",
+    "try:\n",
+    "    data_ops.subtract(sample, other_grid)\n",
+    "except ValueError as e:\n",
+    "    print(f'ValueError: {e}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0991e345",
+   "metadata": {},
+   "source": [
+    "**Other caveats:**\n",
+    "\n",
+    "- **Missing uncertainties (dI)** on an operand trigger a warning - they are treated as\n",
+    "  zero in error propagation. Error-free results warn again at fit time (the `lmfit`\n",
+    "  engine falls back to unit weights; `bumps` refuses to fit).\n",
+    "- **NaN points** propagate through the arithmetic; they are masked in the result\n",
+    "  (excluded from fits) and a warning reports the masked count.\n",
+    "- **Resolution (dQ) propagation** through arithmetic is *not validated* upstream -\n",
+    "  a warning is emitted when any operand carries `dx`/`dxl`/`dxw`. Treat resolution on\n",
+    "  results with care, especially for slit-smeared data.\n",
+    "- Every operation appends a `Process` entry to the result, so the provenance survives\n",
+    "  in saved CanSAS output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "948c1237",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fitter.save_results('background_subtracted_fit.csv')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ai",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/sans_fitter/__init__.py
+++ b/src/sans_fitter/__init__.py
@@ -2,6 +2,7 @@
 SANS Model Fitter - A flexible template for fitting SANS data with SasModels
 """
 
+from . import data_ops
 from .parameter_manager import ParameterManager
 from .polydispersity import PD_DEFAULTS, PD_DISTRIBUTION_TYPES
 from .results import FitResultContract
@@ -15,4 +16,5 @@ __all__ = [
     'PD_DISTRIBUTION_TYPES',
     'get_all_models',
     'FitResultContract',
+    'data_ops',
 ]

--- a/src/sans_fitter/data_loader.py
+++ b/src/sans_fitter/data_loader.py
@@ -30,6 +30,37 @@ def get_fit_index(data: Any) -> np.ndarray:
     return index
 
 
+def normalize_sans_data(data: Any) -> Any:
+    """Ensure *data* carries the qmin/qmax/mask attributes the fit engines need.
+
+    Both fit engines rely on ``qmin``, ``qmax`` and ``mask`` being present on
+    the dataset. Loaded files get them here via :func:`load_sans_data`;
+    datasets built in memory (arithmetic results, simulations) get them via
+    :meth:`SANSFitter.set_data` or :mod:`sans_fitter.data_ops`.
+
+    ``qmin``/``qmax`` are only computed when absent (explicit ``is None``
+    check, so a legitimate limit of ``0.0`` is preserved). The mask is the
+    union of any existing mask and the NaN positions in x, y and — when the
+    columns carry real data — dy and dx.
+    """
+    qmin = getattr(data, 'qmin', None)
+    qmax = getattr(data, 'qmax', None)
+    data.qmin = data.x.min() if qmin is None else qmin
+    data.qmax = data.x.max() if qmax is None else qmax
+
+    existing_mask = getattr(data, 'mask', None)
+    if existing_mask is None or np.asarray(existing_mask).size != np.asarray(data.y).size:
+        existing_mask = np.zeros_like(data.y, dtype=bool)
+    existing_mask = np.asarray(existing_mask, dtype=bool)
+    nan_mask = np.isnan(data.x) | np.isnan(data.y)
+    if _has_real_data(data.dy):
+        nan_mask |= np.isnan(data.dy)
+    if _has_real_data(data.dx):
+        nan_mask |= np.isnan(data.dx)
+    data.mask = existing_mask | nan_mask
+    return data
+
+
 def load_sans_data(filename: str) -> Any:
     """Load SANS data and normalize required fields for downstream fitting."""
     loader = Loader()
@@ -39,22 +70,6 @@ def load_sans_data(filename: str) -> Any:
         if not data_list:
             raise ValueError(f'No data loaded from {filename}')
 
-        data = data_list[0]
-        qmin = getattr(data, 'qmin', None)
-        qmax = getattr(data, 'qmax', None)
-        data.qmin = data.x.min() if qmin is None else qmin
-        data.qmax = data.x.max() if qmax is None else qmax
-
-        existing_mask = np.asarray(
-            getattr(data, 'mask', np.zeros_like(data.y, dtype=bool)),
-            dtype=bool,
-        )
-        nan_mask = np.isnan(data.x) | np.isnan(data.y)
-        if _has_real_data(data.dy):
-            nan_mask |= np.isnan(data.dy)
-        if _has_real_data(data.dx):
-            nan_mask |= np.isnan(data.dx)
-        data.mask = existing_mask | nan_mask
-        return data
+        return normalize_sans_data(data_list[0])
     except Exception as e:
         raise ValueError(f'Failed to load data from {filename}: {str(e)}') from e

--- a/src/sans_fitter/data_ops.py
+++ b/src/sans_fitter/data_ops.py
@@ -1,0 +1,257 @@
+"""
+Dataset arithmetic for SANS data (issue #45).
+
+Notebook-friendly functions to add, subtract, multiply and divide datasets —
+similar to SasView's *Data Operation* utility. Typical uses:
+
+- ``subtract(sample, background)`` — empty-cell / solvent subtraction
+- ``multiply(data, 2.0)`` or ``divide(data, transmission)`` — rescaling
+- ``subtract(data, 0.05)`` — flat background subtraction
+
+The arithmetic itself (including error propagation, e.g.
+``dy = sqrt(dy_a² + dy_b²)`` for addition/subtraction) is delegated to
+sasdata's ``Data1D`` operators; this module wraps them so the results are
+fit-ready (``qmin``/``qmax``/``mask`` set), carry provenance metadata, and
+fail with actionable messages.
+
+Example:
+    >>> from sans_fitter import SANSFitter, data_ops
+    >>> sample = data_ops.load('sample.csv')
+    >>> background = data_ops.load('empty_cell.csv')
+    >>> result = data_ops.subtract(sample, background)
+    >>> result = data_ops.multiply(result, 0.85)
+    >>> fitter = SANSFitter()
+    >>> fitter.set_data(result)
+    >>> fitter.set_model('sphere')
+    >>> fitter.fit()
+
+Limitations:
+    - Both datasets must share the same Q grid (sasdata requires x-values to
+      match within 1% relative tolerance). Interpolation onto a common grid is
+      not yet supported.
+    - Resolution (``dx``/``dxl``/``dxw``) propagation through arithmetic is
+      **not validated** — sasdata combines ``dx`` in an RMS-like way and skips
+      slit-smearing widths. A warning is emitted when resolution data is
+      present on any operand; treat resolution on results with care,
+      especially for slit-smeared data.
+"""
+
+import numbers
+import operator
+import warnings
+from typing import Any, Union
+
+import numpy as np
+from sasdata.dataloader.data_info import Data1D, Data2D, Process
+
+from .data_loader import _has_real_data, load_sans_data, normalize_sans_data
+
+__all__ = ['load', 'add', 'subtract', 'multiply', 'divide']
+
+Operand = Union[Data1D, numbers.Number]
+
+_OPERATORS = {
+    '+': operator.add,
+    '-': operator.sub,
+    '*': operator.mul,
+    '/': operator.truediv,
+}
+
+
+def load(filename: str) -> Data1D:
+    """Load a SANS dataset from a file and return a fit-ready ``Data1D``.
+
+    This is the canonical standalone loader: ``SANSFitter.load_data()`` uses
+    the same implementation, so datasets loaded here behave identically to
+    those loaded through the fitter. Supports CSV, XML and HDF5 formats via
+    sasdata (columnar text files are read in the order Q, I, dI, dQ).
+
+    Args:
+        filename: Path to the data file.
+
+    Returns:
+        A ``Data1D`` object with ``qmin``/``qmax``/``mask`` set.
+
+    Raises:
+        ValueError: If the file cannot be loaded or contains no data.
+    """
+    return load_sans_data(filename)
+
+
+def add(a: Data1D, b: Operand) -> Data1D:
+    """Return ``a + b`` as a new fit-ready dataset.
+
+    ``b`` may be a ``Data1D`` on the same Q grid as ``a`` (intensities are
+    added point-wise, uncertainties combine as ``dy = sqrt(dy_a² + dy_b²)``)
+    or a scalar (``y' = y + b``; ``dy`` and the Q grid are unchanged).
+    """
+    return _operation('+', a, b)
+
+
+def subtract(a: Data1D, b: Operand) -> Data1D:
+    """Return ``a − b`` as a new fit-ready dataset. Order matters.
+
+    Typical use: ``subtract(sample, background)`` for empty-cell / solvent
+    subtraction. ``b`` may be a ``Data1D`` on the same Q grid as ``a``
+    (uncertainties combine as ``dy = sqrt(dy_a² + dy_b²)``) or a scalar for
+    flat background subtraction (``y' = y − b``; ``dy`` and the Q grid are
+    unchanged).
+    """
+    return _operation('-', a, b)
+
+
+def multiply(a: Data1D, b: Operand) -> Data1D:
+    """Return ``a × b`` as a new fit-ready dataset.
+
+    ``b`` may be a ``Data1D`` on the same Q grid as ``a`` (relative
+    uncertainties combine in quadrature) or a scalar (``y' = b·y``,
+    ``dy' = b·dy``; the Q grid is unchanged). Typical scalar use: rescaling
+    to absolute units.
+    """
+    return _operation('*', a, b)
+
+
+def divide(a: Data1D, b: Operand) -> Data1D:
+    """Return ``a / b`` as a new fit-ready dataset. Order matters.
+
+    ``b`` may be a ``Data1D`` on the same Q grid as ``a`` (relative
+    uncertainties combine in quadrature) or a scalar (``y' = y/b``,
+    ``dy' = dy/b``; the Q grid is unchanged). Typical scalar use: dividing by
+    a transmission factor.
+    """
+    return _operation('/', a, b)
+
+
+def _dataset_label(data: Any) -> str:
+    """Short human-readable name for a dataset or scalar, for messages."""
+    if isinstance(data, numbers.Number):
+        return f'{data:g}'
+    for attr in ('filename', 'title', 'name'):
+        value = getattr(data, attr, None)
+        if value:
+            return str(value)
+    return 'dataset'
+
+
+def _validate_operand(obj: Any, position: str, allow_scalar: bool) -> None:
+    """Check that an operand is a usable Data1D (or scalar, if allowed)."""
+    if isinstance(obj, numbers.Number) and not isinstance(obj, bool):
+        if allow_scalar:
+            return
+        raise TypeError(f'The {position} operand must be a Data1D dataset, got a scalar.')
+    if isinstance(obj, Data2D) or getattr(obj, 'qx_data', None) is not None:
+        raise TypeError(
+            f'The {position} operand is 2D data; dataset arithmetic supports 1D data only.'
+        )
+    if not isinstance(obj, Data1D):
+        raise TypeError(
+            f'The {position} operand must be a Data1D dataset or a number, '
+            f'got {type(obj).__name__}.'
+        )
+    x = getattr(obj, 'x', None)
+    y = getattr(obj, 'y', None)
+    if x is None or y is None or np.asarray(x).size == 0 or np.asarray(y).size == 0:
+        raise ValueError(
+            f'The {position} operand ({_dataset_label(obj)}) has no data: '
+            'x and y must be populated.'
+        )
+    if not _has_real_data(getattr(obj, 'dy', None)):
+        warnings.warn(
+            f'The {position} operand ({_dataset_label(obj)}) has no intensity '
+            'uncertainties (dI); they are treated as zero in error propagation.',
+            stacklevel=4,
+        )
+
+
+def _has_resolution(data: Any) -> bool:
+    """True when a dataset carries any resolution information."""
+    if isinstance(data, numbers.Number):
+        return False
+    return any(_has_real_data(getattr(data, attr, None)) for attr in ('dx', 'dxl', 'dxw'))
+
+
+def _masked_count(data: Any) -> int:
+    """Number of NaN intensity points in a dataset (0 for scalars)."""
+    if isinstance(data, numbers.Number):
+        return 0
+    return int(np.sum(np.isnan(np.asarray(data.y, dtype=float))))
+
+
+def _operation(op_symbol: str, a: Data1D, b: Operand) -> Data1D:
+    """Validate operands, run the sasdata operator and finalize the result."""
+    _validate_operand(a, 'first', allow_scalar=False)
+    _validate_operand(b, 'second', allow_scalar=True)
+
+    try:
+        result = _OPERATORS[op_symbol](a, b)
+    except ValueError as e:
+        if isinstance(b, Data1D):
+            raise ValueError(
+                f'Cannot compute {_dataset_label(a)} {op_symbol} {_dataset_label(b)}: '
+                f'{e}. The datasets must share the same Q grid '
+                f'(x-values matching within 1%). '
+                f'{_dataset_label(a)}: {np.asarray(a.x).size} points, '
+                f'Q = [{np.min(a.x):g}, {np.max(a.x):g}]; '
+                f'{_dataset_label(b)}: {np.asarray(b.x).size} points, '
+                f'Q = [{np.min(b.x):g}, {np.max(b.x):g}]. '
+                'Interpolation onto a common grid is not yet supported — '
+                'rebin the data onto matching Q values first.'
+            ) from e
+        raise
+
+    operation = f'{_dataset_label(a)} {op_symbol} {_dataset_label(b)}'
+    return _finalize(result, operation, a, b)
+
+
+def _finalize(result: Data1D, operation: str, a: Data1D, b: Operand) -> Data1D:
+    """Make an arithmetic result fit-ready and record provenance."""
+    # The upstream operators clone metadata from the left operand only and do
+    # not set qmin/qmax/mask, which both fit engines require.
+    result.qmin = None
+    result.qmax = None
+    result.mask = None
+    normalize_sans_data(result)
+
+    result.title = operation
+    result.filename = operation
+    process = Process()
+    process.name = 'sans_fitter.data_ops'
+    process.description = f'Dataset arithmetic: {operation}'
+    if getattr(result, 'process', None) is None:
+        result.process = []
+    result.process.append(process)
+
+    if not _has_real_data(getattr(result, 'dy', None)):
+        warnings.warn(
+            f"Result of '{operation}' has no intensity uncertainties (dI); "
+            'fits will be unweighted.',
+            stacklevel=3,
+        )
+
+    if _has_resolution(a) or _has_resolution(b):
+        warnings.warn(
+            'Resolution data (dQ) is present: propagation of resolution through '
+            'dataset arithmetic is not validated (sasdata combines dx in an '
+            'RMS-like way and ignores slit-smearing widths). Check the result '
+            'before relying on smeared fits.',
+            stacklevel=3,
+        )
+        for attr in ('dx', 'dxl', 'dxw'):
+            values = getattr(result, attr, None)
+            if _has_real_data(values) and np.any(np.nan_to_num(np.asarray(values)) < 0):
+                warnings.warn(
+                    f"Result of '{operation}' has negative {attr} values — the "
+                    'propagated resolution is not physical.',
+                    stacklevel=3,
+                )
+
+    masked_after = _masked_count(result)
+    if masked_after > _masked_count(a):
+        warnings.warn(
+            f"Result of '{operation}' has {masked_after} masked (NaN) intensity "
+            f'points (first operand had {_masked_count(a)}); they are excluded '
+            'from fits.',
+            stacklevel=3,
+        )
+
+    return result

--- a/src/sans_fitter/fitting/scipy_engine.py
+++ b/src/sans_fitter/fitting/scipy_engine.py
@@ -46,7 +46,24 @@ def fit_scipy(
     # sasmodels evaluates the theory only at the fitted points (inside
     # [qmin, qmax], unmasked); compare against the matching data subset.
     y_fit = np.asarray(calculator.Iq)
-    dy_fit = np.asarray(calculator.dIq)
+    dy_fit = np.asarray(calculator.dIq, dtype=float)
+    # Zero dI would make the weighted residual infinite. Weight such points as
+    # 1.0 instead — they will dominate χ² relative to small-error points, but
+    # masking them would silently change the degrees of freedom.
+    zero_dy = np.nan_to_num(dy_fit) == 0
+    if zero_dy.any():
+        if zero_dy.all():
+            warnings.warn(
+                'All intensity uncertainties (dI) are zero; using unweighted residuals.',
+                stacklevel=2,
+            )
+        else:
+            warnings.warn(
+                f'{int(zero_dy.sum())} of {zero_dy.size} fitted points have zero intensity '
+                'uncertainty (dI); weighting them as 1.0.',
+                stacklevel=2,
+            )
+        dy_fit = np.where(zero_dy, 1.0, dy_fit)
 
     def build_parameter_dict(x: np.ndarray) -> dict[str, Any]:
         par_dict = {name: info['value'] for name, info in fit_state.params.items()}

--- a/src/sans_fitter/sans_fitter.py
+++ b/src/sans_fitter/sans_fitter.py
@@ -16,7 +16,7 @@ from sasmodels import core
 from sasmodels.core import load_model
 from sasmodels.direct_model import DirectModel
 
-from .data_loader import _has_real_data, get_fit_index, load_sans_data
+from .data_loader import _has_real_data, get_fit_index, load_sans_data, normalize_sans_data
 from .fitting import SCIPY_AVAILABLE, fit_bumps, fit_scipy
 from .fitting.base import extract_fit_index
 from .parameter_manager import ParameterManager
@@ -100,6 +100,58 @@ class SANSFitter:
         has_dx = _has_real_data(self.data.dx)
 
         print(f'✓ Loaded data from {filename}')
+        print(f'  Q range: {self.data.qmin:.4f} to {self.data.qmax:.4f} Å⁻¹')
+        print(f'  Data points: {len(self.data.x)}')
+        print(f'  Error (dI) column: {"yes" if has_dy else "no"}')
+        print(f'  Resolution (dQ) column: {"yes" if has_dx else "no"}')
+
+    def set_data(self, data: Any) -> None:
+        """
+        Use an in-memory dataset for fitting.
+
+        This is the injection point for datasets that were not loaded from a
+        file: results of dataset arithmetic (see :mod:`sans_fitter.data_ops`),
+        simulated data, or any sasdata ``Data1D`` built programmatically. The
+        dataset is validated and normalized (``qmin``/``qmax``/``mask`` are
+        recomputed as needed) so it is fit-ready.
+
+        Args:
+            data: A sasdata ``Data1D`` object with populated ``x`` and ``y``
+                arrays. 2D data is not supported.
+
+        Raises:
+            TypeError: If the object is 2D data or lacks ``x``/``y`` arrays.
+            ValueError: If ``x``/``y`` are empty, have mismatched lengths, or
+                contain non-positive Q values.
+        """
+        if getattr(data, 'qx_data', None) is not None:
+            raise TypeError('2D data is not supported. Provide a Data1D object.')
+        x = getattr(data, 'x', None)
+        y = getattr(data, 'y', None)
+        if x is None or y is None:
+            raise TypeError('Dataset must have populated x and y arrays.')
+        x = np.asarray(x)
+        y = np.asarray(y)
+        if x.size == 0 or y.size == 0:
+            raise ValueError('Dataset is empty: x and y must contain data points.')
+        if x.size != y.size:
+            raise ValueError(f'x and y have different lengths ({x.size} vs {y.size}).')
+        if np.any(x[np.isfinite(x)] <= 0):
+            raise ValueError('Q values must be positive.')
+        if x.size < 5:
+            warnings.warn(
+                f'Dataset has only {x.size} points; fits may be unreliable.',
+                stacklevel=2,
+            )
+
+        self.data = normalize_sans_data(data)
+        self._full_q_range = (self.data.qmin, self.data.qmax)
+
+        has_dy = _has_real_data(self.data.dy)
+        has_dx = _has_real_data(self.data.dx)
+        label = getattr(data, 'title', '') or getattr(data, 'filename', '') or 'in-memory dataset'
+
+        print(f'✓ Data set: {label}')
         print(f'  Q range: {self.data.qmin:.4f} to {self.data.qmax:.4f} Å⁻¹')
         print(f'  Data points: {len(self.data.x)}')
         print(f'  Error (dI) column: {"yes" if has_dy else "no"}')
@@ -535,14 +587,53 @@ class SANSFitter:
         if self.kernel is None:
             raise ValueError('No model loaded. Use set_model() first.')
 
+        if engine not in ('bumps', 'lmfit'):
+            raise ValueError(f"Unknown engine '{engine}'. Use 'bumps' or 'lmfit'.")
+
+        self._check_fit_uncertainties(engine)
+
         if engine == 'bumps':
             return self._fit_bumps(method or 'amoeba', **kwargs)
-        elif engine == 'lmfit':
-            if not LMFIT_AVAILABLE:
-                raise ValueError("scipy is not installed. Use 'bumps' engine or install scipy.")
-            return self._fit_lmfit(method or 'leastsq', **kwargs)
+        if not LMFIT_AVAILABLE:
+            raise ValueError("scipy is not installed. Use 'bumps' engine or install scipy.")
+        return self._fit_lmfit(method or 'leastsq', **kwargs)
+
+    def _check_fit_uncertainties(self, engine: str) -> None:
+        """Validate intensity uncertainties (dI) before fitting.
+
+        Both engines weight residuals by dI. Zero (or absent) uncertainties
+        make the BUMPS χ² infinite for every parameter set, so the fit cannot
+        proceed; the scipy/lmfit engine falls back to unit weights for the
+        affected points (with a warning from the engine itself).
+        """
+        index = get_fit_index(self.data)
+        dy = getattr(self.data, 'dy', None)
+        if dy is None or np.asarray(dy).size == 0:
+            n_zero = int(index.sum())
         else:
-            raise ValueError(f"Unknown engine '{engine}'. Use 'bumps' or 'lmfit'.")
+            dy_fit = np.asarray(dy, dtype=float)[index]
+            n_zero = int(np.sum(np.nan_to_num(dy_fit) == 0))
+        if n_zero == 0:
+            return
+
+        n_fit = int(index.sum())
+        detail = (
+            'has no intensity uncertainties (dI)'
+            if n_zero == n_fit
+            else f'has {n_zero} of {n_fit} fitted points with zero intensity uncertainty (dI)'
+        )
+        if engine == 'bumps':
+            raise ValueError(
+                f'Data {detail}. The bumps engine cannot weight such points '
+                '(χ² becomes infinite). Provide dI values, exclude the points '
+                "(mask or set_q_range), or use engine='lmfit', which treats "
+                'them as unweighted.'
+            )
+        warnings.warn(
+            f'Data {detail}. Affected residuals will be unweighted (dI treated as 1.0), '
+            'so these points may dominate χ² relative to points with small errors.',
+            stacklevel=2,
+        )
 
     def _fit_bumps(self, method: str = 'amoeba', **kwargs: Any) -> dict[str, Any]:
         """Fit using BUMPS engine."""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -34,6 +34,29 @@ def create_loading_test_data_file_with_resolution(num_points=10):
     return temp_file.name
 
 
+def create_background_data_file(num_points=10):
+    """Flat background on the same Q grid as create_loading_test_data_file."""
+    temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False)
+    temp_file.write('Q,I,dI\n')
+    for index in range(num_points):
+        q_value = 0.01 * (index + 1)
+        temp_file.write(f'{q_value},0.5,0.05\n')
+    temp_file.close()
+    return temp_file.name
+
+
+def create_offset_grid_data_file(num_points=12):
+    """Dataset on a Q grid that does not match create_loading_test_data_file."""
+    temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False)
+    temp_file.write('Q,I,dI\n')
+    for index in range(num_points):
+        q_value = 0.017 * (index + 1)
+        intensity = 50 * np.exp(-q_value * 8) + 0.2
+        temp_file.write(f'{q_value},{intensity},{intensity * 0.1}\n')
+    temp_file.close()
+    return temp_file.name
+
+
 def create_decay_data_file(num_points=30):
     temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False)
     temp_file.write('Q,I,dI\n')

--- a/tests/test_data_ops.py
+++ b/tests/test_data_ops.py
@@ -1,0 +1,370 @@
+import os
+import unittest
+import warnings
+
+import numpy as np
+from sasdata.dataloader.data_info import Data1D
+
+from sans_fitter import SANSFitter, data_ops
+from tests.helpers import (
+    create_background_data_file,
+    create_decay_data_file,
+    create_loading_test_data_file,
+    create_offset_grid_data_file,
+)
+
+
+def make_data1d(num_points=20, y_value=10.0, dy_value=1.0, dx_value=None):
+    """Build an in-memory Data1D on a fixed positive Q grid."""
+    x = np.linspace(0.01, 0.5, num_points)
+    y = np.full(num_points, y_value)
+    dy = None if dy_value is None else np.full(num_points, dy_value)
+    dx = None if dx_value is None else np.full(num_points, dx_value)
+    return Data1D(x=x, y=y, dy=dy, dx=dx)
+
+
+class TestLoad(unittest.TestCase):
+    """data_ops.load is the canonical standalone loader."""
+
+    def setUp(self):
+        self.data_file = create_loading_test_data_file()
+
+    def tearDown(self):
+        if os.path.exists(self.data_file):
+            os.unlink(self.data_file)
+
+    def test_load_returns_fit_ready_data1d(self):
+        data = data_ops.load(self.data_file)
+        self.assertIsInstance(data, Data1D)
+        self.assertEqual(data.qmin, data.x.min())
+        self.assertEqual(data.qmax, data.x.max())
+        self.assertEqual(len(data.mask), len(data.y))
+
+    def test_load_matches_fitter_load_data(self):
+        data = data_ops.load(self.data_file)
+        fitter = SANSFitter()
+        fitter.load_data(self.data_file)
+        np.testing.assert_array_equal(data.x, fitter.data.x)
+        np.testing.assert_array_equal(data.y, fitter.data.y)
+        np.testing.assert_array_equal(data.dy, fitter.data.dy)
+
+    def test_load_missing_file_raises(self):
+        with self.assertRaises(ValueError):
+            data_ops.load('nonexistent_file_xyz.csv')
+
+
+class TestDatasetArithmetic(unittest.TestCase):
+    """Dataset ⊕ dataset operations with hand-computed expectations."""
+
+    def setUp(self):
+        self.sample_file = create_loading_test_data_file()
+        self.background_file = create_background_data_file()
+        self.sample = data_ops.load(self.sample_file)
+        self.background = data_ops.load(self.background_file)
+
+    def tearDown(self):
+        for path in (self.sample_file, self.background_file):
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_subtract_values_and_errors(self):
+        result = data_ops.subtract(self.sample, self.background)
+        np.testing.assert_allclose(result.y, self.sample.y - self.background.y)
+        expected_dy = np.sqrt(self.sample.dy**2 + self.background.dy**2)
+        np.testing.assert_allclose(result.dy, expected_dy)
+
+    def test_add_values_and_errors(self):
+        result = data_ops.add(self.sample, self.background)
+        np.testing.assert_allclose(result.y, self.sample.y + self.background.y)
+        expected_dy = np.sqrt(self.sample.dy**2 + self.background.dy**2)
+        np.testing.assert_allclose(result.dy, expected_dy)
+
+    def test_multiply_values_and_errors(self):
+        result = data_ops.multiply(self.sample, self.background)
+        np.testing.assert_allclose(result.y, self.sample.y * self.background.y)
+        expected_dy = np.abs(result.y) * np.sqrt(
+            (self.sample.dy / self.sample.y) ** 2 + (self.background.dy / self.background.y) ** 2
+        )
+        np.testing.assert_allclose(result.dy, expected_dy)
+
+    def test_divide_values_and_errors(self):
+        result = data_ops.divide(self.sample, self.background)
+        np.testing.assert_allclose(result.y, self.sample.y / self.background.y)
+        expected_dy = np.abs(result.y) * np.sqrt(
+            (self.sample.dy / self.sample.y) ** 2 + (self.background.dy / self.background.y) ** 2
+        )
+        np.testing.assert_allclose(result.dy, expected_dy)
+
+    def test_subtract_is_not_commutative(self):
+        forward = data_ops.subtract(self.sample, self.background)
+        reverse = data_ops.subtract(self.background, self.sample)
+        np.testing.assert_allclose(forward.y, self.sample.y - self.background.y)
+        np.testing.assert_allclose(reverse.y, self.background.y - self.sample.y)
+        self.assertFalse(np.allclose(forward.y, reverse.y))
+
+    def test_q_grid_preserved(self):
+        result = data_ops.subtract(self.sample, self.background)
+        np.testing.assert_array_equal(result.x, self.sample.x)
+
+
+class TestScalarArithmetic(unittest.TestCase):
+    """Dataset ⊕ scalar semantics."""
+
+    def setUp(self):
+        self.data = make_data1d(y_value=10.0, dy_value=1.0)
+
+    def test_multiply_by_scalar(self):
+        result = data_ops.multiply(self.data, 2.0)
+        np.testing.assert_allclose(result.y, 20.0)
+        np.testing.assert_allclose(result.dy, 2.0)
+        np.testing.assert_array_equal(result.x, self.data.x)
+
+    def test_divide_by_scalar(self):
+        result = data_ops.divide(self.data, 2.0)
+        np.testing.assert_allclose(result.y, 5.0)
+        np.testing.assert_allclose(result.dy, 0.5)
+        np.testing.assert_array_equal(result.x, self.data.x)
+
+    def test_subtract_scalar_keeps_dy(self):
+        result = data_ops.subtract(self.data, 0.05)
+        np.testing.assert_allclose(result.y, 9.95)
+        np.testing.assert_allclose(result.dy, 1.0)
+        np.testing.assert_array_equal(result.x, self.data.x)
+
+    def test_add_scalar(self):
+        result = data_ops.add(self.data, 0.5)
+        np.testing.assert_allclose(result.y, 10.5)
+        np.testing.assert_allclose(result.dy, 1.0)
+
+
+class TestFitReadiness(unittest.TestCase):
+    """Arithmetic results can be fed straight into SANSFitter."""
+
+    def setUp(self):
+        self.data_file = create_decay_data_file()
+
+    def tearDown(self):
+        if os.path.exists(self.data_file):
+            os.unlink(self.data_file)
+
+    def test_result_has_fit_attributes(self):
+        data = data_ops.load(self.data_file)
+        result = data_ops.subtract(data, 0.005)
+        self.assertEqual(result.qmin, result.x.min())
+        self.assertEqual(result.qmax, result.x.max())
+        self.assertEqual(len(result.mask), len(result.y))
+        self.assertFalse(result.mask.any())
+
+    def test_end_to_end_set_data_and_fit(self):
+        data = data_ops.load(self.data_file)
+        result = data_ops.subtract(data, 0.005)
+
+        fitter = SANSFitter()
+        fitter.set_data(result)
+        fitter.set_model('sphere')
+        fitter.set_param('radius', value=20.0, min=10.0, max=30.0, vary=True)
+        fitter.set_param('scale', value=0.1, min=0.01, max=1.0, vary=True)
+        fitter.set_param('background', value=0.005, min=0, max=0.1, vary=True)
+        fitter.set_param('sld', value=2.0, vary=False)
+        fitter.set_param('sld_solvent', value=3.0, vary=False)
+
+        fit_result = fitter.fit(engine='lmfit', method='leastsq')
+        self.assertTrue(np.isfinite(fit_result['chisq']))
+
+
+class TestOperandValidation(unittest.TestCase):
+    """Rejection of unusable operands with actionable messages."""
+
+    def setUp(self):
+        self.sample_file = create_loading_test_data_file()
+        self.offset_file = create_offset_grid_data_file()
+
+    def tearDown(self):
+        for path in (self.sample_file, self.offset_file):
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_mismatched_q_grids_raise_with_diagnostics(self):
+        sample = data_ops.load(self.sample_file)
+        offset = data_ops.load(self.offset_file)
+        with self.assertRaises(ValueError) as ctx:
+            data_ops.subtract(sample, offset)
+        message = str(ctx.exception)
+        self.assertIn('Q grid', message)
+        self.assertIn('10 points', message)
+        self.assertIn('12 points', message)
+        self.assertIn(os.path.basename(self.sample_file), message)
+        self.assertIn(os.path.basename(self.offset_file), message)
+
+    def test_2d_data_rejected(self):
+        class Fake2D:
+            qx_data = np.array([0.1, 0.2])
+
+        with self.assertRaises(TypeError):
+            data_ops.subtract(make_data1d(), Fake2D())
+
+    def test_non_numeric_operand_rejected(self):
+        with self.assertRaises(TypeError):
+            data_ops.subtract(make_data1d(), 'not a dataset')
+
+    def test_scalar_first_operand_rejected(self):
+        with self.assertRaises(TypeError):
+            data_ops.subtract(2.0, make_data1d())
+
+    def test_empty_operand_rejected(self):
+        empty = Data1D(x=np.array([]), y=np.array([]))
+        with self.assertRaises(ValueError):
+            data_ops.subtract(make_data1d(), empty)
+
+    def test_missing_dy_warns(self):
+        no_errors = make_data1d(dy_value=None)
+        with self.assertWarnsRegex(UserWarning, 'no intensity uncertainties'):
+            data_ops.subtract(make_data1d(), no_errors)
+
+
+class TestNaNPropagation(unittest.TestCase):
+    """NaN points propagate through matching-grid operations and get masked."""
+
+    def test_nan_in_second_operand_is_masked_and_warned(self):
+        a = make_data1d()
+        b = make_data1d(y_value=5.0, dy_value=0.5)
+        b.y[3] = np.nan
+
+        with self.assertWarnsRegex(UserWarning, 'masked'):
+            result = data_ops.subtract(a, b)
+
+        self.assertTrue(np.isnan(result.y[3]))
+        self.assertTrue(result.mask[3])
+        self.assertEqual(int(result.mask.sum()), 1)
+
+
+class TestZeroErrorHandling(unittest.TestCase):
+    """Zero/absent dI: warnings and engine guards."""
+
+    def setUp(self):
+        self.data_file = create_decay_data_file()
+
+    def tearDown(self):
+        if os.path.exists(self.data_file):
+            os.unlink(self.data_file)
+
+    def _error_free_fitter(self):
+        data = data_ops.load(self.data_file)
+        data.dy = np.zeros_like(data.y)
+        fitter = SANSFitter()
+        fitter.set_data(data)
+        fitter.set_model('sphere')
+        fitter.set_param('radius', value=20.0, min=10.0, max=30.0, vary=True)
+        fitter.set_param('scale', value=0.1, min=0.01, max=1.0, vary=True)
+        fitter.set_param('background', value=0.01, min=0, max=0.1, vary=True)
+        fitter.set_param('sld', value=2.0, vary=False)
+        fitter.set_param('sld_solvent', value=3.0, vary=False)
+        return fitter
+
+    def test_error_free_result_warns(self):
+        a = make_data1d(dy_value=None)
+        b = make_data1d(y_value=2.0, dy_value=None)
+        with self.assertWarnsRegex(UserWarning, 'no intensity uncertainties'):
+            result = data_ops.subtract(a, b)
+        np.testing.assert_allclose(result.y, 8.0)
+
+    def test_lmfit_engine_handles_zero_dy(self):
+        fitter = self._error_free_fitter()
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            result = fitter.fit(engine='lmfit', method='leastsq')
+        self.assertTrue(np.isfinite(result['chisq']))
+
+    def test_bumps_engine_rejects_zero_dy(self):
+        fitter = self._error_free_fitter()
+        with self.assertRaises(ValueError) as ctx:
+            fitter.fit(engine='bumps')
+        self.assertIn('bumps engine cannot weight', str(ctx.exception))
+
+
+class TestSetData(unittest.TestCase):
+    """SANSFitter.set_data validation."""
+
+    def test_set_valid_data(self):
+        fitter = SANSFitter()
+        data = make_data1d()
+        fitter.set_data(data)
+        self.assertIs(fitter.data, data)
+        self.assertEqual(fitter.data.qmin, data.x.min())
+        self.assertEqual(fitter.data.qmax, data.x.max())
+        self.assertEqual(fitter.get_q_range(), (data.x.min(), data.x.max()))
+
+    def test_empty_data_rejected(self):
+        fitter = SANSFitter()
+        with self.assertRaises(ValueError):
+            fitter.set_data(Data1D(x=np.array([]), y=np.array([])))
+
+    def test_non_positive_q_rejected(self):
+        fitter = SANSFitter()
+        data = Data1D(x=np.array([-0.1, 0.1, 0.2]), y=np.ones(3))
+        with self.assertRaises(ValueError):
+            fitter.set_data(data)
+
+    def test_missing_arrays_rejected(self):
+        fitter = SANSFitter()
+        with self.assertRaises(TypeError):
+            fitter.set_data(object())
+
+    def test_few_points_warns(self):
+        fitter = SANSFitter()
+        data = Data1D(x=np.array([0.1, 0.2, 0.3]), y=np.ones(3), dy=np.full(3, 0.1))
+        with self.assertWarnsRegex(UserWarning, 'only 3 points'):
+            fitter.set_data(data)
+
+
+class TestMetadata(unittest.TestCase):
+    """Provenance: title, filename and process history."""
+
+    def setUp(self):
+        self.sample_file = create_loading_test_data_file()
+        self.background_file = create_background_data_file()
+
+    def tearDown(self):
+        for path in (self.sample_file, self.background_file):
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_title_and_process_record_operation(self):
+        sample = data_ops.load(self.sample_file)
+        background = data_ops.load(self.background_file)
+        result = data_ops.subtract(sample, background)
+
+        self.assertIn('-', result.title)
+        self.assertIn(os.path.basename(self.sample_file), result.title)
+        self.assertIn(os.path.basename(self.background_file), result.title)
+        self.assertTrue(result.process)
+        self.assertEqual(result.process[-1].name, 'sans_fitter.data_ops')
+        self.assertIn('Dataset arithmetic', result.process[-1].description)
+
+    def test_scalar_operation_recorded(self):
+        sample = data_ops.load(self.sample_file)
+        result = data_ops.multiply(sample, 2.0)
+        self.assertIn('* 2', result.title)
+
+
+class TestResolutionWarning(unittest.TestCase):
+    """Resolution (dx) present on an operand triggers the caveat warning."""
+
+    def test_dx_triggers_warning(self):
+        a = make_data1d(dx_value=0.001)
+        b = make_data1d(y_value=2.0, dy_value=0.2, dx_value=0.002)
+        with self.assertWarnsRegex(UserWarning, 'Resolution'):
+            data_ops.subtract(a, b)
+
+    def test_no_dx_no_resolution_warning(self):
+        a = make_data1d()
+        b = make_data1d(y_value=2.0, dy_value=0.2)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            data_ops.subtract(a, b)
+        messages = [str(w.message) for w in caught]
+        self.assertFalse(any('Resolution' in m for m in messages))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request adds a new `data_ops` module for dataset arithmetic, enabling users to add, subtract, multiply, and divide SANS datasets (or scale by constants) with proper error propagation. 

**New dataset arithmetic functionality:**

* Introduced the `data_ops` module, which provides functions to add, subtract, multiply, and divide SANS datasets or datasets with scalars, propagating uncertainties and recording provenance. This enables pre-fit operations like background subtraction and transmission correction. 

* Added an script (`examples/data_operations_example.py`) and an interactive notebook (`notebooks/data_operations_demo.ipynb`) illustrating typical use cases and error handling.

**API and codebase updates:**

* Exposed `data_ops` at the top-level API by importing and including it in `__all__` in `src/sans_fitter/__init__.py`. 
* Refactored data loading logic in `src/sans_fitter/data_loader.py` by splitting out `normalize_sans_data`, ensuring all datasets (including in-memory arithmetic results) are normalized for fitting. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dataset arithmetic for adding, subtracting, multiplying, and dividing SANS datasets or scalar values.
  * Added uncertainty propagation, provenance tracking, validation, and fit-ready results.
  * Added support for injecting processed datasets directly into fitting workflows.
  * Added examples and a notebook covering background subtraction and transmission correction.

* **Bug Fixes**
  * Improved handling of missing, zero, and invalid uncertainties during fitting.
  * Added normalization and masking for incomplete or invalid data points.

* **Documentation**
  * Expanded API, usage, and feature documentation for dataset operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->