### PR TITLE
Multi-model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,58 @@ fitter.remove_structure_factor()
 - **Radius handling:** use `radius_effective_mode='link_radius'` to keep `radius_effective` equal to the form-factor `radius`, or leave the default `unconstrained` to fit it independently.
 - **State helpers:** `get_structure_factor()` returns the active structure factor so notebooks/scripts can branch as needed.
 
+## Combining Models
+
+Describe a dataset with several models at once — for example a low-Q diffuse
+feature plus a high-Q peak — fitted simultaneously against one dataset:
+
+```python
+fitter = SANSFitter()
+fitter.load_data('data.csv')
+
+# Combine models; parameters get friendly per-model prefixes
+fitter.set_models('dab', 'peak_lorentz')
+fitter.set_param('dab_cor_length', value=50, min=1, max=500, vary=True)
+fitter.set_param('peak_lorentz_peak_pos', value=0.1, min=0.01, max=0.5, vary=True)
+fitter.set_param('background', value=0.001, min=0, max=0.1, vary=True)
+
+result = fitter.fit(engine='bumps')
+
+# See which feature each model accounts for
+fitter.plot_results(show_components=True)
+```
+
+The combined intensity is
+
+$I(q) = \text{scale} \cdot \sum_i \text{scale}_i \cdot I_i(q) + \text{background}$
+
+so the global `scale` and `background` are shared by all components natively,
+while each component has its own `<model>_scale`.
+
+**Custom names (monikers)** — for long model names, duplicates, or physics labels:
+
+```python
+fitter.set_models(small='sphere', large='sphere', shared=['sld', 'sld_solvent'])
+fitter.set_param('small_radius', value=20, vary=True)
+fitter.set_param('large_radius', value=200, vary=True)
+```
+
+**Sharing parameters** — any name in `shared=[...]` that exists in ≥ 2
+components becomes a single unprefixed parameter driving all of them
+(`sld` above). Polydispersity configuration stays per-component under the
+prefixed names.
+
+**Component curves** — after fitting a `'+'` mixture, `plot_results(show_components=True)`
+overlays one dashed curve per component, each drawn as
+`scale · part_scale · I_part(q)` (background shown implicitly in the total).
+
+> **Advanced:** the raw sasmodels expression syntax is also available and keeps
+> sasmodels' native `A_`/`B_` names: `fitter.set_model('dab+peak_lorentz')`.
+> For after-the-fact or asymmetric sharing, use equality links:
+> `fitter.link_params('large_sld', to='small_sld')` and
+> `fitter.unlink_params('large_sld')`. Composite models and parameter links
+> currently require the `bumps` engine.
+
 ## Bayesian Analysis
 
 Sample the full posterior distribution of the varying parameters with the

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,6 +15,11 @@ The main class for SANS data fitting.
         - reset_q_range
         - get_q_range
         - set_model
+        - set_models
+        - link_params
+        - unlink_params
+        - get_links
+        - get_components
         - set_structure_factor
         - get_params
         - set_param
@@ -36,6 +41,27 @@ The main class for SANS data fitting.
         - is_polydispersity_enabled
         - get_pd_params
         - get_varying_pd_params
+
+### Composite model naming
+
+`set_models()` exposes parameters under friendly alias names; `set_model()`
+with a composite expression keeps sasmodels' canonical names. Both spellings
+are accepted by `set_param()`, `link_params()`, `set_pd_param()` and
+`get_pd_param()`. For `set_models('dab', 'peak_lorentz')`:
+
+| Friendly alias (`set_models`) | Canonical name (`set_model`) |
+|---|---|
+| `scale`, `background` | `scale`, `background` (shared natively) |
+| `dab_scale` | `A_scale` |
+| `dab_cor_length` | `A_cor_length` |
+| `peak_lorentz_scale` | `B_scale` |
+| `peak_lorentz_peak_pos` | `B_peak_pos` |
+| `peak_lorentz_peak_hwhm` | `B_peak_hwhm` |
+
+With keyword monikers (`set_models(small='sphere', large='sphere')`) the
+prefix is the moniker (`small_radius` → `A_radius`). Parameters listed in
+`shared=` collapse to a single unprefixed name (`sld` → `A_sld` + `B_sld`);
+their prefixed aliases remain addressable for polydispersity configuration.
 
 ## PosteriorSummary
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -210,6 +210,106 @@ When using a structure factor, you often need to define an effective radius. You
 fitter.set_structure_factor('hardsphere', radius_effective_mode='link_radius')
 ```
 
+### Combining Models (Composite Models)
+
+Datasets with several distinct features — for example a low-Q diffuse
+scattering contribution plus a high-Q correlation peak — are often best
+described by *several models fitted simultaneously* against the same data.
+`set_models()` combines any sasmodels models into one fit:
+
+```python
+fitter = SANSFitter()
+fitter.load_data('data.csv')
+
+fitter.set_models('dab', 'peak_lorentz')
+fitter.set_param('dab_cor_length', value=50, min=1, max=500, vary=True)
+fitter.set_param('dab_scale', value=10, min=0.1, max=100, vary=True)
+fitter.set_param('peak_lorentz_peak_pos', value=0.1, min=0.01, max=0.5, vary=True)
+fitter.set_param('peak_lorentz_peak_hwhm', value=0.01, min=0.001, max=0.1, vary=True)
+fitter.set_param('background', value=0.001, min=0, max=0.1, vary=True)
+
+result = fitter.fit(engine='bumps')
+fitter.plot_results(show_components=True)
+```
+
+**How the combination works.** With the default `operation='+'` the combined
+intensity is
+
+    I(q) = scale · [dab_scale·I_dab(q) + peak_lorentz_scale·I_peak(q)] + background
+
+The global `scale` and `background` are shared by every component natively
+(sasmodels' mixture semantics), while each component carries its own
+`<name>_scale`. Varying the global `scale` together with a component scale is
+degenerate — only their product is fitted — so `fit()` warns when both are
+free. With `operation='*'` the part intensities multiply instead.
+
+**Friendly parameter names.** Every component parameter is prefixed with the
+model name (`dab_cor_length`, `peak_lorentz_peak_pos`). Give components custom
+names (monikers) with keyword arguments — useful for long model names,
+duplicates, or physics labels:
+
+```python
+fitter.set_models(small='sphere', large='sphere', shared=['sld', 'sld_solvent'])
+fitter.set_param('small_radius', value=20, min=5, max=100, vary=True)
+fitter.set_param('large_radius', value=200, min=50, max=1000, vary=True)
+fitter.set_param('sld', value=4.0, vary=True)   # one knob drives both spheres
+```
+
+**Sharing parameters.** Each name in `shared=[...]` must exist in at least
+two components; it becomes a single unprefixed parameter driving all of them
+(the per-component versions disappear from the parameter list). This is the
+one-line answer to "share SLD across models". Note that polydispersity
+configuration stays per-component: after `shared=['radius']`,
+`set_pd_param('small_radius', ...)` and `set_pd_param('large_radius', ...)`
+still configure the two components independently.
+
+**Structure factors on one part.** A component entry may itself contain `@`,
+applying a structure factor to that part only:
+
+```python
+fitter.set_models('sphere@hardsphere', 'peak_lorentz')
+```
+
+(`@` binds tighter than `+`, so this is `(sphere@hardsphere) + peak_lorentz`.)
+Applying `set_structure_factor()` to an already-composite model raises an
+error — sasmodels cannot express `(A+B)@S`.
+
+**Component curves.** After fitting a `'+'` mixture,
+`plot_results(show_components=True)` overlays one dashed curve per component,
+each drawn as `scale · part_scale · I_part(q)` (background excluded, shown
+implicitly in the total curve). For `'*'` mixtures and atomic models the flag
+is a documented no-op.
+
+**Equality links.** For sharing that `shared=` cannot express — linking only
+some components, or parameters with different names — use explicit links:
+
+```python
+fitter.link_params('large_sld', to='small_sld')      # follower mirrors target
+fitter.link_params('shell_sld_core', to='small_sld') # different names work too
+fitter.unlink_params('large_sld')                    # escape hatch
+```
+
+A follower is forced `vary=False` and mirrors the target's value before,
+during, and after the fit; writing it directly raises. Link chains are not
+supported.
+
+**Raw string syntax (advanced).** `set_model()` accepts sasmodels' native
+composite expressions directly and keeps the canonical `A_`/`B_` parameter
+names — zero magic when following sasmodels documentation:
+
+```python
+fitter.set_model('dab+peak_lorentz')   # A_scale, A_cor_length, B_scale, ...
+```
+
+Every atomic name in the expression is validated before loading, with a
+nearest-match suggestion for typos.
+
+**Engine support.** Composite models and parameter links currently work with
+the `bumps` engine only; `fit(engine='lmfit')` and `fit_bayesian()` raise
+`NotImplementedError` when either is active.
+
+See `examples/composite_model_example.py` for a complete runnable example.
+
 ## Polydispersity
 
 SANS Fitter supports polydispersity, which models size distributions in your samples. Many real samples have a distribution of particle sizes rather than a single monodisperse size.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -235,7 +235,9 @@ fitter.plot_results(show_components=True)
 **How the combination works.** With the default `operation='+'` the combined
 intensity is
 
-    I(q) = scale · [dab_scale·I_dab(q) + peak_lorentz_scale·I_peak(q)] + background
+```text
+I(q) = scale · [dab_scale·I_dab(q) + peak_lorentz_scale·I_peak(q)] + background
+```
 
 The global `scale` and `background` are shared by every component natively
 (sasmodels' mixture semantics), while each component carries its own

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -263,6 +263,14 @@ configuration stays per-component: after `shared=['radius']`,
 `set_pd_param('small_radius', ...)` and `set_pd_param('large_radius', ...)`
 still configure the two components independently.
 
+**One component per entry.** Each `set_models()` entry must be a single
+component (optionally with `@`, see below). An entry that is itself a
+composite expression — e.g. `set_models(diffuse='dab+peak_lorentz',
+particle='sphere')` — raises an error, because the two entries would expand
+to three kernel components and the monikers could not map 1:1. Pass each
+component separately, or use the raw string path
+(`set_model('dab+peak_lorentz+sphere')`) with canonical `A_`/`B_`/`C_` names.
+
 **Structure factors on one part.** A component entry may itself contain `@`,
 applying a structure factor to that part only:
 

--- a/examples/composite_model_example.py
+++ b/examples/composite_model_example.py
@@ -135,6 +135,10 @@ fitter3.link_params('large_sld', to='small_sld')
 print('\nActive links:', fitter3.get_links())
 
 fitter3.set_param('small_sld', value=4.0, min=0, max=8, vary=True)
+# Match the solvent SLD the data was simulated with (the sphere default is
+# 6.0); otherwise the fit compensates through small_sld and recovers ~3.6.
+fitter3.set_param('small_sld_solvent', value=6.4, vary=False)
+fitter3.set_param('large_sld_solvent', value=6.4, vary=False)
 fitter3.set_param('small_radius', value=15, min=5, max=100, vary=True)
 fitter3.set_param('large_radius', value=150, min=50, max=1000, vary=True)
 fitter3.set_param('scale', value=0.1, min=0.001, max=1, vary=True)

--- a/examples/composite_model_example.py
+++ b/examples/composite_model_example.py
@@ -1,0 +1,155 @@
+"""
+Example: Combining Multiple Models (Composite Models)
+
+This script demonstrates how to:
+1. Simulate data with a low-Q diffuse feature plus a high-Q peak
+2. Combine two models (dab + peak_lorentz) against the single dataset
+3. Configure per-component parameters with friendly names
+4. Fit with the bumps engine
+5. Visualize per-component curves
+6. Share parameters across components and use equality links
+
+Composite models let you describe a dataset that needs more than one physical
+model — the motivating case from issue #46: a low-Q diffuse contribution
+(dab) together with a high-Q correlation peak (peak_lorentz), sharing a common
+background.
+"""
+
+import numpy as np
+from sasdata.dataloader.data_info import Data1D
+from sasmodels.core import load_model
+from sasmodels.direct_model import DirectModel
+
+from sans_fitter import SANSFitter
+
+
+def simulate_composite_data():
+    """Generate synthetic dab + peak_lorentz data on a realistic Q grid."""
+    q = np.linspace(0.005, 0.3, 80)
+    data = Data1D(x=q, y=np.ones_like(q), dy=np.full_like(q, 0.05))
+    data.qmin, data.qmax = q.min(), q.max()
+
+    kernel = load_model('dab+peak_lorentz', dtype='single', platform='dll')
+    truth = dict(
+        scale=1.0,
+        background=0.01,
+        A_scale=10.0,
+        A_cor_length=50.0,
+        B_scale=5.0,
+        B_peak_pos=0.1,
+        B_peak_hwhm=0.01,
+    )
+    y = np.asarray(DirectModel(data, kernel)(**truth))
+    rng = np.random.default_rng(42)
+    data.y = y + rng.normal(0, 0.02 * y, size=y.shape)
+    return data
+
+
+# ============================================================================
+# Part 1: Combine two models with friendly names
+# ============================================================================
+
+print('=' * 80)
+print('Part 1: Combine dab + peak_lorentz against one dataset')
+print('=' * 80)
+
+fitter = SANSFitter()
+fitter.set_data(simulate_composite_data())
+
+# Combine the models; parameters get friendly per-model prefixes
+fitter.set_models('dab', 'peak_lorentz')
+
+print('\nCombined-model parameters:')
+fitter.get_params()
+
+# Configure the parameters (global scale/background are shared natively)
+fitter.set_param('dab_cor_length', value=40, min=1, max=500, vary=True)
+fitter.set_param('dab_scale', value=8, min=0.1, max=100, vary=True)
+fitter.set_param('peak_lorentz_peak_pos', value=0.08, min=0.01, max=0.5, vary=True)
+fitter.set_param('peak_lorentz_peak_hwhm', value=0.008, min=0.001, max=0.1, vary=True)
+fitter.set_param('peak_lorentz_scale', value=4, min=0.1, max=100, vary=True)
+fitter.set_param('background', value=0.005, min=0, max=0.1, vary=True)
+
+# Fit with the bumps engine (composite models require bumps)
+result = fitter.fit(engine='bumps', method='amoeba')
+
+# Overlay one dashed curve per component to see which feature each model fits
+fitter.plot_results(show_components=True, show=False)
+
+# ============================================================================
+# Part 2: Custom monikers and shared parameters
+# ============================================================================
+
+print('\n' + '=' * 80)
+print('Part 2: Monikers and shared parameters (two sphere populations)')
+print('=' * 80)
+
+# Build two-sphere data sharing a contrast
+q = np.linspace(0.005, 0.3, 80)
+data = Data1D(x=q, y=np.ones_like(q), dy=np.full_like(q, 0.05))
+data.qmin, data.qmax = q.min(), q.max()
+kernel = load_model('sphere+sphere', dtype='single', platform='dll')
+truth = dict(
+    scale=0.1, background=0.001,
+    A_sld=4.0, A_sld_solvent=6.4, A_radius=20.0, A_scale=1.0,
+    B_sld=4.0, B_sld_solvent=6.4, B_radius=200.0, B_scale=1.0,
+)
+data.y = np.asarray(DirectModel(data, kernel)(**truth))
+
+fitter2 = SANSFitter()
+fitter2.set_data(data)
+
+# Monikers label the components; shared=['sld', 'sld_solvent'] collapses the
+# contrast into single unprefixed parameters driving both spheres.
+fitter2.set_models(small='sphere', large='sphere', shared=['sld', 'sld_solvent'])
+
+print('\nTwo-sphere parameters (contrast shared):')
+fitter2.get_params()
+
+fitter2.set_param('sld', value=4.0, min=0, max=8, vary=True)
+fitter2.set_param('sld_solvent', value=6.4, vary=False)
+fitter2.set_param('small_radius', value=15, min=5, max=100, vary=True)
+fitter2.set_param('large_radius', value=150, min=50, max=1000, vary=True)
+fitter2.set_param('scale', value=0.1, min=0.001, max=1, vary=True)
+fitter2.set_param('background', value=0.001, min=0, max=0.1, vary=True)
+
+result2 = fitter2.fit(engine='bumps', method='amoeba')
+fitter2.plot_results(show_components=True, show=False)
+
+# ============================================================================
+# Part 3: Equality links for asymmetric sharing
+# ============================================================================
+
+print('\n' + '=' * 80)
+print('Part 3: Equality links (link_params)')
+print('=' * 80)
+
+# link_params handles sharing that shared= cannot express: linking only some
+# components, or parameters with different names.
+fitter3 = SANSFitter()
+fitter3.set_data(data)
+fitter3.set_models(small='sphere', large='sphere')
+
+# Force the large sphere to share the small sphere's SLD
+fitter3.link_params('large_sld', to='small_sld')
+print('\nActive links:', fitter3.get_links())
+
+fitter3.set_param('small_sld', value=4.0, min=0, max=8, vary=True)
+fitter3.set_param('small_radius', value=15, min=5, max=100, vary=True)
+fitter3.set_param('large_radius', value=150, min=50, max=1000, vary=True)
+fitter3.set_param('scale', value=0.1, min=0.001, max=1, vary=True)
+fitter3.set_param('background', value=0.001, min=0, max=0.1, vary=True)
+
+result3 = fitter3.fit(engine='bumps', method='amoeba')
+
+# The follower mirrors the target after the fit
+print(f"\nsmall_sld = {fitter3.params['small_sld']['value']:.4f}")
+print(f"large_sld = {fitter3.params['large_sld']['value']:.4f} (linked)")
+
+# Remove the link to restore independence
+fitter3.unlink_params('large_sld')
+print('Links after unlink:', fitter3.get_links())
+
+print('\n' + '=' * 80)
+print('Done. See docs/usage.md "Combining Models" for details.')
+print('=' * 80)

--- a/notebooks/composite_models.ipynb
+++ b/notebooks/composite_models.ipynb
@@ -1,0 +1,223 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0b841968",
+   "metadata": {},
+   "source": [
+    "# Composite Models: Multiple Models per Dataset\n",
+    "\n",
+    "Real datasets often need more than one physical model. A classic case\n",
+    "([issue #46](https://github.com/ai4se1dk/SANS-fitter/issues/46)): a low-Q\n",
+    "diffuse feature plus a high-Q correlation peak, best described by a **dab**\n",
+    "model and a **peak_lorentz** model fitted *simultaneously* against the same\n",
+    "data — sharing a common background.\n",
+    "\n",
+    "This notebook demonstrates:\n",
+    "\n",
+    "1. Simulating composite data with sasmodels\n",
+    "2. Combining models with `set_models()` (friendly parameter names)\n",
+    "3. Fitting with the bumps engine\n",
+    "4. Per-component curves (`show_components=True`)\n",
+    "5. Sharing parameters across components (`shared=`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e92b5ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from sasdata.dataloader.data_info import Data1D\n",
+    "from sasmodels.core import load_model\n",
+    "from sasmodels.direct_model import DirectModel\n",
+    "\n",
+    "from sans_fitter import SANSFitter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "649ad714",
+   "metadata": {},
+   "source": [
+    "## 1. Simulate low-Q diffuse + high-Q peak data\n",
+    "\n",
+    "The combined intensity of a `'+'` mixture is\n",
+    "\n",
+    "$$I(q) = \\text{scale} \\cdot \\sum_i \\text{scale}_i \\cdot I_i(q) + \\text{background}$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1530ae1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q = np.linspace(0.005, 0.3, 80)\n",
+    "data = Data1D(x=q, y=np.ones_like(q), dy=np.full_like(q, 0.05))\n",
+    "data.qmin, data.qmax = q.min(), q.max()\n",
+    "\n",
+    "kernel = load_model('dab+peak_lorentz', dtype='single', platform='dll')\n",
+    "truth = dict(\n",
+    "    scale=1.0, background=0.01,\n",
+    "    A_scale=10.0, A_cor_length=50.0,\n",
+    "    B_scale=5.0, B_peak_pos=0.1, B_peak_hwhm=0.01,\n",
+    ")\n",
+    "y = np.asarray(DirectModel(data, kernel)(**truth))\n",
+    "rng = np.random.default_rng(42)\n",
+    "data.y = y + rng.normal(0, 0.02 * y, size=y.shape)\n",
+    "print(f'Simulated {len(q)} points of dab+peak_lorentz data')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c886a84",
+   "metadata": {},
+   "source": [
+    "## 2. Combine the models\n",
+    "\n",
+    "`set_models()` gives every component parameter a friendly prefix\n",
+    "(`dab_cor_length` instead of sasmodels' canonical `A_cor_length`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "355fdc58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fitter = SANSFitter()\n",
+    "fitter.set_data(data)\n",
+    "fitter.set_models('dab', 'peak_lorentz')\n",
+    "fitter.get_params()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9546adcb",
+   "metadata": {},
+   "source": [
+    "## 3. Configure and fit\n",
+    "\n",
+    "The global `scale` and `background` are shared natively; each component has\n",
+    "its own `<name>_scale`. Composite models require the `bumps` engine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3b0d6bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fitter.set_param('dab_cor_length', value=40, min=1, max=500, vary=True)\n",
+    "fitter.set_param('dab_scale', value=8, min=0.1, max=100, vary=True)\n",
+    "fitter.set_param('peak_lorentz_peak_pos', value=0.08, min=0.01, max=0.5, vary=True)\n",
+    "fitter.set_param('peak_lorentz_peak_hwhm', value=0.008, min=0.001, max=0.1, vary=True)\n",
+    "fitter.set_param('peak_lorentz_scale', value=4, min=0.1, max=100, vary=True)\n",
+    "fitter.set_param('background', value=0.005, min=0, max=0.1, vary=True)\n",
+    "\n",
+    "result = fitter.fit(engine='bumps', method='amoeba')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2b7c28c",
+   "metadata": {},
+   "source": [
+    "## 4. Per-component curves\n",
+    "\n",
+    "`show_components=True` overlays one dashed curve per component, each drawn as\n",
+    "`scale · part_scale · I_part(q)` (background shown implicitly in the total)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c55e041",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fitter.plot_results(show_components=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d993fb1",
+   "metadata": {},
+   "source": [
+    "## 5. Sharing parameters across components\n",
+    "\n",
+    "`shared=[...]` collapses a parameter that exists in ≥ 2 components into a\n",
+    "single unprefixed knob driving all of them — here, two sphere populations\n",
+    "with a common contrast."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7549ad3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q2 = np.linspace(0.005, 0.3, 80)\n",
+    "data2 = Data1D(x=q2, y=np.ones_like(q2), dy=np.full_like(q2, 0.05))\n",
+    "data2.qmin, data2.qmax = q2.min(), q2.max()\n",
+    "kernel2 = load_model('sphere+sphere', dtype='single', platform='dll')\n",
+    "truth2 = dict(\n",
+    "    scale=0.1, background=0.001,\n",
+    "    A_sld=4.0, A_sld_solvent=6.4, A_radius=20.0, A_scale=1.0,\n",
+    "    B_sld=4.0, B_sld_solvent=6.4, B_radius=200.0, B_scale=1.0,\n",
+    ")\n",
+    "data2.y = np.asarray(DirectModel(data2, kernel2)(**truth2))\n",
+    "\n",
+    "fitter2 = SANSFitter()\n",
+    "fitter2.set_data(data2)\n",
+    "fitter2.set_models(small='sphere', large='sphere', shared=['sld', 'sld_solvent'])\n",
+    "fitter2.get_params()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6a69dd9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fitter2.set_param('sld', value=4.0, min=0, max=8, vary=True)\n",
+    "fitter2.set_param('sld_solvent', value=6.4, vary=False)\n",
+    "fitter2.set_param('small_radius', value=15, min=5, max=100, vary=True)\n",
+    "fitter2.set_param('large_radius', value=150, min=50, max=1000, vary=True)\n",
+    "fitter2.set_param('scale', value=0.1, min=0.001, max=1, vary=True)\n",
+    "fitter2.set_param('background', value=0.001, min=0, max=0.1, vary=True)\n",
+    "\n",
+    "result2 = fitter2.fit(engine='bumps', method='amoeba')\n",
+    "fitter2.plot_results(show_components=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97d2d45d",
+   "metadata": {},
+   "source": [
+    "## Further reading\n",
+    "\n",
+    "- `docs/usage.md` — \"Combining Models (Composite Models)\" walkthrough\n",
+    "- `examples/composite_model_example.py` — runnable script version\n",
+    "- Equality links (`link_params` / `unlink_params`) for asymmetric sharing\n",
+    "- Raw sasmodels syntax: `set_model('dab+peak_lorentz')` keeps `A_`/`B_` names"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/sans_fitter/contracts.py
+++ b/src/sans_fitter/contracts.py
@@ -1,10 +1,15 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional
 
 
 @dataclass(slots=True)
 class ParameterStateSnapshot:
-    """Read-only parameter state passed into fitting engines."""
+    """Read-only parameter state passed into fitting engines.
+
+    All parameter names carried by the snapshot are **canonical sasmodels
+    names** (e.g. ``A_sld`` under a composite model). Any user-facing alias
+    layer is translated away before the snapshot is built.
+    """
 
     params: dict[str, dict[str, Any]]
     polydisperse_param_names: list[str]
@@ -14,3 +19,9 @@ class ParameterStateSnapshot:
     structure_factor_name: Optional[str]
     varying_params: list[str]
     varying_pd_params: list[str]
+    # Equality links (follower -> target), canonical names. Populated by
+    # link_params() and by the shared= sugar of set_models().
+    linked_params: dict[str, str] = field(default_factory=dict)
+    # Composite-model components as (prefix, moniker, part_model_name)
+    # triples; empty for atomic models.
+    components: tuple[tuple[str, str, str], ...] = ()

--- a/src/sans_fitter/fitting/bumps_engine.py
+++ b/src/sans_fitter/fitting/bumps_engine.py
@@ -83,6 +83,14 @@ def _build_bumps_problem(
 
     link_radius_effective_model(model, fit_state.radius_effective_mode)
 
+    # Generic equality links (composite models / shared= / link_params):
+    # alias the follower's bumps parameter object to the target's, the exact
+    # mechanism the radius link uses. Followers are never in the varying set,
+    # so they don't appear in problem.labels(); their post-fit value comes
+    # from apply_fitted_values propagation, not from the engine.
+    for follower, target in fit_state.linked_params.items():
+        setattr(model, follower, getattr(model, target))
+
     experiment = Experiment(data=data, model=model)
     problem = FitProblem(experiment)
     return problem, experiment

--- a/src/sans_fitter/fitting/bumps_engine.py
+++ b/src/sans_fitter/fitting/bumps_engine.py
@@ -88,7 +88,21 @@ def _build_bumps_problem(
     # mechanism the radius link uses. Followers are never in the varying set,
     # so they don't appear in problem.labels(); their post-fit value comes
     # from apply_fitted_values propagation, not from the engine.
+    # Precondition: the link graph has depth 1 — no target is itself a
+    # follower — so the aliasing below is independent of dict order.
+    # ParameterManager guarantees this (link_params rejects chains in both
+    # directions; snapshot_fit_state re-points shared followers to the one
+    # canonical target).
+    followers = set(fit_state.linked_params)
+    assert not followers & set(fit_state.linked_params.values()), (
+        'Link chains are not supported by the bumps aliasing mechanism.'
+    )
     for follower, target in fit_state.linked_params.items():
+        if follower == 'radius_effective' and fit_state.radius_effective_mode == 'link_radius':
+            raise ValueError(
+                "'radius_effective' is already linked to 'radius' by "
+                "radius_effective_mode='link_radius'. Remove one of the links."
+            )
         setattr(model, follower, getattr(model, target))
 
     experiment = Experiment(data=data, model=model)

--- a/src/sans_fitter/parameter_manager.py
+++ b/src/sans_fitter/parameter_manager.py
@@ -7,6 +7,7 @@ composite-model component metadata, the friendly-name alias layer, and generic
 parameter equality links.
 """
 
+import warnings
 from typing import Any, Optional
 
 import numpy as np
@@ -42,7 +43,13 @@ def derive_mixture_components(kernel: Any) -> list[tuple[str, str, str]]:
     parts = composition[1]
     try:
         kernel_names = [param.name for param in info.parameters.kernel_parameters]
-    except Exception:
+    except Exception as exc:  # noqa: BLE001 - mock kernels may expose anything
+        warnings.warn(
+            f'Could not read kernel parameters of mixture model: {exc!r}. '
+            'Treating the model as atomic — component features (aliases, '
+            'monikers, component curves) are disabled.',
+            stacklevel=2,
+        )
         return []
 
     components: list[tuple[str, str, str]] = []
@@ -65,7 +72,13 @@ def derive_mixture_components(kernel: Any) -> list[tuple[str, str, str]]:
                 prefix = block[0].split('_')[0]
             part_name = getattr(part, 'name', '') or ''
             components.append((prefix, prefix, part_name))
-    except Exception:
+    except Exception as exc:  # noqa: BLE001 - mock kernels may expose anything
+        warnings.warn(
+            f'Could not derive components of mixture model: {exc!r}. '
+            'Treating the model as atomic — component features (aliases, '
+            'monikers, component curves) are disabled.',
+            stacklevel=2,
+        )
         return []
     return components
 
@@ -452,17 +465,34 @@ class ParameterManager:
                 components and are collapsed into a single unprefixed parameter.
 
         Raises:
-            ValueError: If a shared name is present in fewer than 2 components,
-                or if the generated alias set has collisions.
+            ValueError: If a model entry expanded to more than one kernel
+                component (monikers could not map 1:1), if a shared name is
+                present in fewer than 2 components, or if the generated alias
+                set has collisions.
+
+        Note:
+            This method is atomic: all validation runs against local state, and
+            ``self.*`` is only mutated once every check has passed. On failure
+            the manager is left exactly as ``set_model`` configured it.
         """
-        # Update monikers in the kernel-derived triples by position.
-        for i, (moniker, _model_name) in enumerate(components):
-            if i < len(self._components):
-                prefix, _old_moniker, part_name = self._components[i]
-                self._components[i] = (prefix, moniker, part_name)
+        if len(components) != len(self._components):
+            raise ValueError(
+                f'{len(components)} model entries expanded to {len(self._components)} kernel '
+                'components (a nested mixture expression or mixture plugin). Pass each '
+                'component separately so monikers map 1:1.'
+            )
+
+        # Overlay the user's monikers onto the kernel-derived triples by
+        # position — into a local list; self._components is committed last.
+        new_components = [
+            (prefix, moniker, part_name)
+            for (prefix, _old_moniker, part_name), (moniker, _model_name) in zip(
+                self._components, components
+            )
+        ]
 
         # Longest-prefix-first so nested combined prefixes (e.g. 'AB') win.
-        comps = sorted(self._components, key=lambda c: len(c[0]), reverse=True)
+        comps = sorted(new_components, key=lambda c: len(c[0]), reverse=True)
 
         alias_to_canonical: dict[str, str] = {}
         canonical_to_alias: dict[str, str] = {}
@@ -489,7 +519,7 @@ class ParameterManager:
         shared_to_canonicals: dict[str, list[str]] = {}
         for shared_name in shared:
             canonicals = []
-            for prefix, _moniker, _part_name in self._components:
+            for prefix, _moniker, _part_name in new_components:
                 candidate = f'{prefix}_{shared_name}' if prefix else shared_name
                 if candidate in self.params:
                     canonicals.append(candidate)
@@ -501,7 +531,7 @@ class ParameterManager:
                         for name in self.params
                         if prefix and name.startswith(prefix + '_')
                     )
-                    for prefix, moniker, _part in self._components
+                    for prefix, moniker, _part in new_components
                 )
                 raise ValueError(
                     f"Shared parameter '{shared_name}' must exist in at least 2 "
@@ -538,6 +568,7 @@ class ParameterManager:
             else:
                 new_params[canonical_to_alias[canonical]] = info
 
+        self._components = new_components
         self.params = new_params
         self._alias_to_canonical = alias_to_canonical
         self._canonical_to_alias = canonical_to_alias
@@ -675,13 +706,17 @@ class ParameterManager:
             for name in sorted(shared_names):
                 if name in self.params:
                     print('  ' + entry_line(name, self.params[name]))
-        for prefix, moniker, part_name in self._components:
+        for _prefix, moniker, part_name in self._components:
             label = moniker if moniker == part_name else f'{moniker} ({part_name})'
             print(f'{label}:')
             for name, info in self.params.items():
                 if name in global_names or name in shared_names:
                     continue
-                if name.startswith(f'{moniker}_') or name.startswith(f'{prefix}_'):
+                # Moniker alone covers both paths: params are keyed by alias
+                # after register_aliases, and moniker == prefix on the raw
+                # set_model path. Also matching the prefix would misfile
+                # params when one component's moniker equals another's prefix.
+                if name.startswith(f'{moniker}_'):
                     print('  ' + entry_line(name, info))
         print(f'{"=" * 80}\n')
 

--- a/src/sans_fitter/parameter_manager.py
+++ b/src/sans_fitter/parameter_manager.py
@@ -395,9 +395,7 @@ class ParameterManager:
         if follower == target:
             raise ValueError(f"Cannot link parameter '{name}' to itself.")
         if follower in self._links:
-            raise ValueError(
-                f"Parameter '{name}' is already linked to '{self._links[follower]}'."
-            )
+            raise ValueError(f"Parameter '{name}' is already linked to '{self._links[follower]}'.")
         if target in self._links:
             raise ValueError(
                 f"Cannot link '{name}' to '{to}': '{to}' is itself a follower. "
@@ -535,9 +533,7 @@ class ParameterManager:
                 if shared_to_canonicals[shared_name][0] == canonical:
                     new_params[shared_name] = info
                 # Suppress the prefixed alias of a shared parameter.
-                prefixed_alias = next(
-                    a for a, c in alias_to_canonical.items() if c == canonical
-                )
+                prefixed_alias = next(a for a, c in alias_to_canonical.items() if c == canonical)
                 suppressed.add(prefixed_alias)
             else:
                 new_params[canonical_to_alias[canonical]] = info

--- a/src/sans_fitter/parameter_manager.py
+++ b/src/sans_fitter/parameter_manager.py
@@ -2,7 +2,9 @@
 Parameter Manager - Handles model parameter management for SANS fitting.
 
 This module encapsulates all parameter-related operations including initialization,
-validation, bounds management, structure factor parameter linking, and polydispersity.
+validation, bounds management, structure factor parameter linking, polydispersity,
+composite-model component metadata, the friendly-name alias layer, and generic
+parameter equality links.
 """
 
 from typing import Any, Optional
@@ -11,7 +13,61 @@ import numpy as np
 
 from .contracts import ParameterStateSnapshot
 from .polydispersity import PolydispersityManager
-from .structure_factor import StructureFactorManager
+from .structure_factor import StructureFactorManager, default_parameter_bounds
+
+
+def derive_mixture_components(kernel: Any) -> list[tuple[str, str, str]]:
+    """Derive ``(prefix, moniker, part_model_name)`` triples for a mixture kernel.
+
+    The derivation walks the kernel's composition tree and reads each part's
+    actual prefix from the prefixed names in
+    ``kernel.info.parameters.kernel_parameters`` — the user's expression string
+    is never the prefix authority (sasmodels renumbers prefixes for nested
+    mixture plugins). For flat atomic/product parts the result equals
+    part-order prefixing. The moniker is set to the prefix; the alias layer
+    (:meth:`ParameterManager.register_aliases`) replaces it for the
+    ``set_models`` path.
+
+    Returns an empty list for atomic (non-mixture) models.
+    """
+    info = getattr(kernel, 'info', None)
+    composition = getattr(info, 'composition', None) if info is not None else None
+    # Defensive: mock kernels or atomic models may expose anything here. Only
+    # a real ('mixture', parts) tuple proceeds.
+    if not isinstance(composition, (tuple, list)) or len(composition) != 2:
+        return []
+    if composition[0] != 'mixture':
+        return []
+    operation = getattr(info, 'operation', '+')
+    parts = composition[1]
+    try:
+        kernel_names = [param.name for param in info.parameters.kernel_parameters]
+    except Exception:
+        return []
+
+    components: list[tuple[str, str, str]] = []
+    try:
+        cursor = 0
+        for part in parts:
+            prefix = ''
+            if operation == '+':
+                # Every '+' part contributes a leading {prefix}_scale parameter;
+                # its name carries the part's actual prefix ('A_scale', or the
+                # combined 'AB_scale' form for nested product-mixture plugins).
+                scale_name = kernel_names[cursor] if cursor < len(kernel_names) else ''
+                if scale_name.endswith('scale'):
+                    prefix = scale_name[: -len('scale')].rstrip('_')
+                cursor += 1
+            n_part_params = len(part.parameters.kernel_parameters)
+            block = kernel_names[cursor : cursor + n_part_params]
+            cursor += n_part_params
+            if not prefix and block:
+                prefix = block[0].split('_')[0]
+            part_name = getattr(part, 'name', '') or ''
+            components.append((prefix, prefix, part_name))
+    except Exception:
+        return []
+    return components
 
 
 class ParameterManager:
@@ -36,6 +92,21 @@ class ParameterManager:
         self.model_name: Optional[str] = None
         self._sf_manager = StructureFactorManager()
         self._pd_manager = PolydispersityManager()
+
+        # Composite-model state (see 46_COMPOSITE_MODELS.md)
+        # _components: ordered (prefix, moniker, part_model_name) triples.
+        self._components: list[tuple[str, str, str]] = []
+        # _links: equality links, follower -> target, stored under whatever
+        # names self.params uses (aliases on the set_models path, canonical
+        # names on the raw set_model path).
+        self._links: dict[str, str] = {}
+        # Alias layer (set_models path only): alias -> canonical name. Shared
+        # parameters additionally map one alias to several canonical names.
+        self._alias_to_canonical: dict[str, str] = {}
+        self._canonical_to_alias: dict[str, str] = {}
+        self._shared_to_canonicals: dict[str, list[str]] = {}
+        # Aliases suppressed from the user-facing params dict (shared= entries).
+        self._suppressed_aliases: set[str] = set()
 
     @property
     def _structure_factor_name(self) -> Optional[str]:
@@ -93,13 +164,21 @@ class ParameterManager:
     def _backed_up_pd_state(self, value: Optional[dict[str, Any]]) -> None:
         self._pd_manager.backup_state = value
 
-    def initialize_from_kernel(self, kernel: Any, model_name: str) -> None:
+    def initialize_from_kernel(
+        self,
+        kernel: Any,
+        model_name: str,
+        components: Optional[list[tuple[str, str, str]]] = None,
+    ) -> None:
         """
         Initialize parameters from a SasModels kernel.
 
         Args:
             kernel: SasModels kernel object
             model_name: Name of the model
+            components: Optional ordered ``(prefix, moniker, part_model_name)``
+                triples for composite models. Defaults to deriving components
+                from the kernel's composition tree (empty for atomic models).
 
         Raises:
             ValueError: If kernel is invalid
@@ -111,13 +190,17 @@ class ParameterManager:
         self.clear()
 
         self.model_name = model_name
+        if components is None:
+            components = derive_mixture_components(kernel)
+        self._components = [tuple(entry) for entry in components]
 
         # Extract parameters from kernel
         for param in kernel.info.parameters.kernel_parameters:
+            lo, hi = default_parameter_bounds(param.default, param.limits)
             self.params[param.name] = {
                 'value': param.default,
-                'min': param.limits[0] if param.limits[0] > -np.inf else 0,
-                'max': param.limits[1] if param.limits[1] < np.inf else param.default * 10,
+                'min': lo,
+                'max': hi,
                 'vary': False,  # By default, parameters are fixed
                 'description': param.description,
             }
@@ -165,10 +248,74 @@ class ParameterManager:
         """
         return {name: info['value'] for name, info in self.params.items()}
 
+    def get_canonical_param_values(self) -> dict[str, float]:
+        """Get current parameter values keyed by canonical sasmodels names.
+
+        Shared parameters expand to every canonical name they drive. Used by
+        post-fit evaluation (component curves) that speaks sasmodels names.
+        """
+        values: dict[str, float] = {}
+        for name, info in self.params.items():
+            canonicals = self._shared_to_canonicals.get(name)
+            if canonicals:
+                for canonical in canonicals:
+                    values[canonical] = info['value']
+            else:
+                values[self._resolve_canonical(name)] = info['value']
+        return values
+
     def snapshot_fit_state(self) -> ParameterStateSnapshot:
-        """Capture a stable snapshot of parameter state for fitting engines."""
+        """Capture a stable snapshot of parameter state for fitting engines.
+
+        The snapshot carries **canonical sasmodels names only**: alias-keyed
+        entries are emitted under their canonical names, shared parameters
+        expand to their first canonical name as the link target plus equality
+        links from the remaining canonical names, and ``_links`` (stored under
+        user-facing names) is translated to canonical names here — the one and
+        only translation site for links.
+        """
+        canonical_params: dict[str, dict[str, Any]] = {}
+        linked_params: dict[str, str] = {}
+
+        for name, info in self.params.items():
+            canonicals = self._shared_to_canonicals.get(name)
+            if canonicals:
+                # Shared parameter: one user-facing entry drives several
+                # canonical parameters. Emit the first as the target and link
+                # the rest to it.
+                target = canonicals[0]
+                canonical_params[target] = dict(info)
+                for follower in canonicals[1:]:
+                    canonical_params[follower] = dict(info)
+                    canonical_params[follower]['vary'] = False
+                    linked_params[follower] = target
+            else:
+                canonical = self._alias_to_canonical.get(name, name)
+                canonical_params[canonical] = dict(info)
+
+        # Translate equality links (stored in user-facing names) to canonical.
+        for follower, target in self._links.items():
+            follower_canonicals = self._shared_to_canonicals.get(follower, [follower])
+            target_canonicals = self._shared_to_canonicals.get(target, [target])
+            for follower_canonical in follower_canonicals:
+                follower_canonical = self._alias_to_canonical.get(
+                    follower_canonical, follower_canonical
+                )
+                target_canonical = self._alias_to_canonical.get(
+                    target_canonicals[0], target_canonicals[0]
+                )
+                linked_params[follower_canonical] = target_canonical
+                if follower_canonical in canonical_params:
+                    canonical_params[follower_canonical]['vary'] = False
+
+        varying = [
+            name
+            for name, info in canonical_params.items()
+            if info['vary'] and name not in linked_params
+        ]
+
         return ParameterStateSnapshot(
-            params={name: dict(info) for name, info in self.params.items()},
+            params=canonical_params,
             polydisperse_param_names=self._pd_manager.get_parameters(),
             polydisperse_params={
                 name: dict(info) for name, info in self._pd_manager.params.items()
@@ -176,19 +323,243 @@ class ParameterManager:
             pd_enabled=self._pd_manager.is_enabled(),
             radius_effective_mode=self._radius_effective_mode,
             structure_factor_name=self._structure_factor_name,
-            varying_params=self.get_varying_params(),
+            varying_params=varying,
             varying_pd_params=self.get_varying_pd_params(),
+            linked_params=linked_params,
+            components=tuple(self._components),
         )
 
     def apply_fitted_values(self, fitted_values: dict[str, float]) -> None:
-        """Apply fitted values back into regular and PD parameter state."""
+        """Apply fitted values back into regular and PD parameter state.
+
+        Engine results carry canonical names; they are translated back through
+        the reverse alias map before write-back so a fitted ``A_sld`` lands on
+        the user-facing ``sld`` entry.
+        """
         for name, value in fitted_values.items():
             if name in self.params:
                 self.set_param(name, value=value)
+            elif name in self._canonical_to_alias:
+                self.set_param(self._canonical_to_alias[name], value=value)
             elif name.endswith('_pd'):
                 base_param = name[:-3]
+                # PD state is keyed by canonical names end-to-end; no reverse
+                # translation is needed here.
                 if base_param in self._pd_manager.get_parameters():
                     self.set_pd_param(base_param, pd_width=value)
+
+        # Propagate each link target's fitted value onto its followers.
+        # Followers are excluded from the varying set, so engine results never
+        # contain a follower name — this post-loop propagation is the
+        # follower's *only* update path. Do not remove it as apparently dead.
+        for follower, target in self._links.items():
+            if target in self.params and follower in self.params:
+                self.params[follower]['value'] = self.params[target]['value']
+
+    def resolve_name(self, name: str) -> str:
+        """Resolve a user-facing parameter name to the key used in ``params``.
+
+        Resolution rule: try the alias map first, fall back to canonical names
+        (so ``A_sld`` always works), then raise ``KeyError`` listing the
+        user-facing (alias) names.
+        """
+        if name in self.params:
+            return name
+        if name in self._alias_to_canonical:
+            canonical = self._alias_to_canonical[name]
+            if canonical in self.params:
+                return canonical
+            # Alias of a suppressed (shared) prefixed entry: not in params.
+            return name
+        if name in self._canonical_to_alias:
+            return self._canonical_to_alias[name]
+        available = ', '.join(self.params.keys())
+        raise KeyError(f"Parameter '{name}' not found. Available: {available}")
+
+    def link_params(self, name: str, to: str) -> None:
+        """Create an equality link: *name* (follower) mirrors *to* (target).
+
+        The follower is forced to ``vary=False`` and always carries the
+        target's value — before, during, and after the fit.
+
+        Raises:
+            KeyError: If either name does not exist.
+            ValueError: On self-links, link chains, or conflicting links.
+        """
+        follower = self.resolve_name(name)
+        target = self.resolve_name(to)
+        for resolved, original in ((follower, name), (target, to)):
+            if resolved not in self.params:
+                available = ', '.join(self.params.keys())
+                raise KeyError(f"Parameter '{original}' not found. Available: {available}")
+        if follower == target:
+            raise ValueError(f"Cannot link parameter '{name}' to itself.")
+        if follower in self._links:
+            raise ValueError(
+                f"Parameter '{name}' is already linked to '{self._links[follower]}'."
+            )
+        if target in self._links:
+            raise ValueError(
+                f"Cannot link '{name}' to '{to}': '{to}' is itself a follower. "
+                'Link chains are not supported — link both followers directly '
+                'to the common target.'
+            )
+        if follower in self._links.values():
+            raise ValueError(
+                f"Cannot make '{name}' a follower: it is the target of another "
+                'link. Link chains are not supported — link both followers '
+                'directly to the common target.'
+            )
+        self._links[follower] = target
+        self.params[follower]['vary'] = False
+        self.params[follower]['value'] = self.params[target]['value']
+
+    def unlink_params(self, name: str) -> None:
+        """Remove an equality link, restoring the follower's independence.
+
+        Raises:
+            KeyError: If the name does not exist.
+            ValueError: If the parameter is not a follower.
+        """
+        follower = self.resolve_name(name)
+        if follower not in self._links:
+            raise ValueError(f"Parameter '{name}' is not linked to another parameter.")
+        del self._links[follower]
+
+    def get_links(self) -> dict[str, str]:
+        """Return the equality links (follower -> target) in user-facing names."""
+        return dict(self._links)
+
+    def get_components(self) -> list[tuple[str, str, str]]:
+        """Return composite components as (prefix, moniker, part_model_name) triples.
+
+        Empty for atomic models.
+        """
+        return [tuple(entry) for entry in self._components]
+
+    # =========================================================================
+    # Alias layer (set_models path) — see 46_COMPOSITE_MODELS.md §4.2b
+    # =========================================================================
+
+    def register_aliases(
+        self, components: list[tuple[str, str]], shared: 'list[str] | tuple[str, ...]'
+    ) -> None:
+        """Build the friendly-name alias layer over a loaded composite model.
+
+        Args:
+            components: Ordered ``(moniker, model_name)`` pairs as given to
+                ``set_models``. Monikers replace the prefix-derived monikers in
+                the component triples by position.
+            shared: Parameter names (unprefixed) that must exist in >= 2
+                components and are collapsed into a single unprefixed parameter.
+
+        Raises:
+            ValueError: If a shared name is present in fewer than 2 components,
+                or if the generated alias set has collisions.
+        """
+        # Update monikers in the kernel-derived triples by position.
+        for i, (moniker, _model_name) in enumerate(components):
+            if i < len(self._components):
+                prefix, _old_moniker, part_name = self._components[i]
+                self._components[i] = (prefix, moniker, part_name)
+
+        # Longest-prefix-first so nested combined prefixes (e.g. 'AB') win.
+        comps = sorted(self._components, key=lambda c: len(c[0]), reverse=True)
+
+        alias_to_canonical: dict[str, str] = {}
+        canonical_to_alias: dict[str, str] = {}
+        for canonical in self.params.keys():
+            matched = None
+            for prefix, moniker, _part_name in comps:
+                if prefix and canonical.startswith(prefix + '_'):
+                    matched = (prefix, moniker)
+                    break
+            if matched is None:
+                continue  # global parameter (scale/background) — no alias
+            prefix, moniker = matched
+            stripped = canonical[len(prefix) + 1 :]
+            alias = f'{moniker}_{stripped}'
+            if alias in alias_to_canonical and alias_to_canonical[alias] != canonical:
+                raise ValueError(
+                    f"Component monikers produce a colliding parameter name '{alias}' "
+                    f"(from both '{alias_to_canonical[alias]}' and '{canonical}'). "
+                    'Choose distinct monikers.'
+                )
+            alias_to_canonical[alias] = canonical
+
+        # Shared parameters: one-to-many, must exist in >= 2 components.
+        shared_to_canonicals: dict[str, list[str]] = {}
+        for shared_name in shared:
+            canonicals = []
+            for prefix, _moniker, _part_name in self._components:
+                candidate = f'{prefix}_{shared_name}' if prefix else shared_name
+                if candidate in self.params:
+                    canonicals.append(candidate)
+            if len(canonicals) < 2:
+                per_component = '; '.join(
+                    f'{moniker}: '
+                    + ', '.join(
+                        name[len(prefix) + 1 :]
+                        for name in self.params
+                        if prefix and name.startswith(prefix + '_')
+                    )
+                    for prefix, moniker, _part in self._components
+                )
+                raise ValueError(
+                    f"Shared parameter '{shared_name}' must exist in at least 2 "
+                    f'components (found in {len(canonicals)}). '
+                    f'Per-component parameters — {per_component}'
+                )
+            shared_to_canonicals[shared_name] = canonicals
+            # The shared canonical names reverse-map to the shared alias.
+            for canonical in canonicals:
+                canonical_to_alias[canonical] = shared_name
+
+        # Non-shared canonical names reverse-map to their prefixed alias.
+        for alias, canonical in alias_to_canonical.items():
+            if canonical not in canonical_to_alias:
+                canonical_to_alias[canonical] = alias
+
+        # Re-key the user-facing params dict to alias names.
+        new_params: dict[str, dict[str, Any]] = {}
+        suppressed: set[str] = set()
+        shared_canonical_set = {
+            canonical for canonicals in shared_to_canonicals.values() for canonical in canonicals
+        }
+        for canonical, info in self.params.items():
+            if canonical not in alias_to_canonical.values():
+                new_params[canonical] = info  # global scale/background
+                continue
+            if canonical in shared_canonical_set:
+                shared_name = canonical_to_alias[canonical]
+                if shared_to_canonicals[shared_name][0] == canonical:
+                    new_params[shared_name] = info
+                # Suppress the prefixed alias of a shared parameter.
+                prefixed_alias = next(
+                    a for a, c in alias_to_canonical.items() if c == canonical
+                )
+                suppressed.add(prefixed_alias)
+            else:
+                new_params[canonical_to_alias[canonical]] = info
+
+        self.params = new_params
+        self._alias_to_canonical = alias_to_canonical
+        self._canonical_to_alias = canonical_to_alias
+        self._shared_to_canonicals = shared_to_canonicals
+        self._suppressed_aliases = suppressed
+
+    def _resolve_canonical(self, name: str) -> str:
+        """Map an alias (or canonical) name to its canonical sasmodels name."""
+        return self._alias_to_canonical.get(name, name)
+
+    def to_display_name(self, canonical_name: str) -> str:
+        """Translate a canonical sasmodels name to its user-facing name.
+
+        Used for engine results, saved CSVs, and plot labels on the
+        ``set_models`` path. On the raw ``set_model`` path the alias map is
+        empty and names pass through unchanged.
+        """
+        return self._canonical_to_alias.get(canonical_name, canonical_name)
 
     def set_param(
         self,
@@ -202,7 +573,7 @@ class ParameterManager:
         Configure a model parameter.
 
         Args:
-            name: Parameter name
+            name: Parameter name (alias or canonical)
             value: Initial value (optional)
             min: Minimum bound (optional)
             max: Maximum bound (optional)
@@ -210,26 +581,41 @@ class ParameterManager:
 
         Raises:
             KeyError: If parameter name doesn't exist
+            ValueError: If the parameter is a link follower and value/vary is
+                written, or if vary=True is requested for a follower.
         """
-        if name not in self.params:
+        resolved = self.resolve_name(name)
+        if resolved not in self.params:
             available = ', '.join(self.params.keys())
             raise KeyError(f"Parameter '{name}' not found. Available: {available}")
 
+        if resolved in self._links:
+            target = self._links[resolved]
+            if value is not None or vary is True:
+                raise ValueError(
+                    f"Parameter '{name}' is linked to '{target}' and cannot be "
+                    'set directly. Configure the target, or unlink_params() first.'
+                )
+
         if value is not None:
-            self.params[name]['value'] = value
+            self.params[resolved]['value'] = value
             # Sync radius_effective when radius is updated in link_radius mode
             if (
-                name == 'radius'
+                resolved == 'radius'
                 and self._radius_effective_mode == 'link_radius'
                 and 'radius_effective' in self.params
             ):
                 self.params['radius_effective']['value'] = value
+            # Propagate to equality-link followers of this parameter.
+            for follower, link_target in self._links.items():
+                if link_target == resolved:
+                    self.params[follower]['value'] = value
         if min is not None:
-            self.params[name]['min'] = min
+            self.params[resolved]['min'] = min
         if max is not None:
-            self.params[name]['max'] = max
+            self.params[resolved]['max'] = max
         if vary is not None:
-            self.params[name]['vary'] = vary
+            self.params[resolved]['vary'] = vary
 
     def validate_param(self, name: str) -> bool:
         """
@@ -244,7 +630,12 @@ class ParameterManager:
         return name in self.params
 
     def display_params(self) -> None:
-        """Display current parameter values and settings in a readable format."""
+        """Display current parameter values and settings in a readable format.
+
+        For composite models the parameters are grouped: global parameters
+        first, then shared parameters (from ``shared=``), then one block per
+        component moniker.
+        """
         if not self.params:
             print('No parameters available.')
             return
@@ -255,19 +646,64 @@ class ParameterManager:
             print(f'Structure Factor: {self._structure_factor_name}')
             print(f'Radius Effective Mode: {self._radius_effective_mode}')
         print(f'{"=" * 80}')
-        print(f'{"Parameter":<20} {"Value":<12} {"Min":<12} {"Max":<12} {"Vary":<8}')
+
+        if not self._components:
+            self._print_param_table(self.params)
+            print(f'{"=" * 80}\n')
+            return
+
+        global_names = {'scale', 'background'}
+        shared_names = set(self._shared_to_canonicals.keys())
+
+        def entry_line(name: str, info: dict[str, Any]) -> str:
+            vary_str = '✓' if info['vary'] else '✗'
+            if name == 'radius_effective' and self._radius_effective_mode == 'link_radius':
+                vary_str = '→radius'
+            if name in self._links:
+                vary_str = f'→{self._links[name]}'
+            return (
+                f'{name:<28} {info["value"]:<12.4g} {info["min"]:<12.4g} '
+                f'{info["max"]:<12.4g} {vary_str:<8}'
+            )
+
+        header = f'{"Parameter":<28} {"Value":<12} {"Min":<12} {"Max":<12} {"Vary":<8}'
+        print(header)
         print(f'{"-" * 80}')
 
-        for name, info in self.params.items():
+        print('Global:')
+        for name in ('scale', 'background'):
+            if name in self.params:
+                print('  ' + entry_line(name, self.params[name]))
+        if shared_names:
+            print('Shared:')
+            for name in sorted(shared_names):
+                if name in self.params:
+                    print('  ' + entry_line(name, self.params[name]))
+        for prefix, moniker, part_name in self._components:
+            label = moniker if moniker == part_name else f'{moniker} ({part_name})'
+            print(f'{label}:')
+            for name, info in self.params.items():
+                if name in global_names or name in shared_names:
+                    continue
+                if name.startswith(f'{moniker}_') or name.startswith(f'{prefix}_'):
+                    print('  ' + entry_line(name, info))
+        print(f'{"=" * 80}\n')
+
+    def _print_param_table(self, params: dict[str, dict[str, Any]]) -> None:
+        """Print a flat parameter table (atomic models)."""
+        print(f'{"Parameter":<20} {"Value":<12} {"Min":<12} {"Max":<12} {"Vary":<8}')
+        print(f'{"-" * 80}')
+        for name, info in params.items():
             vary_str = '✓' if info['vary'] else '✗'
             # Show linked indicator for radius_effective in link_radius mode
             if name == 'radius_effective' and self._radius_effective_mode == 'link_radius':
                 vary_str = '→radius'
+            if name in self._links:
+                vary_str = f'→{self._links[name]}'
             print(
                 f'{name:<20} {info["value"]:<12.4g} {info["min"]:<12.4g} '
                 f'{info["max"]:<12.4g} {vary_str:<8}'
             )
-        print(f'{"=" * 80}\n')
 
     def backup_params(self) -> None:
         """Backup current parameters (used before applying structure factor)."""
@@ -429,6 +865,9 @@ class ParameterManager:
             KeyError: If base_param is not a polydisperse parameter
             ValueError: If pd_type is not a valid distribution type
         """
+        # Polydispersity state is keyed by canonical names end-to-end; resolve
+        # aliases (e.g. 'small_radius' -> 'A_radius') before delegating.
+        base_param = self._resolve_canonical(base_param)
         self._pd_manager.set_param(
             base_param,
             pd_width=pd_width,
@@ -452,6 +891,7 @@ class ParameterManager:
         Raises:
             KeyError: If base_param is not a polydisperse parameter
         """
+        base_param = self._resolve_canonical(base_param)
         return self._pd_manager.get_param(base_param)
 
     def toggle_pd_visibility(self, enabled: bool) -> None:
@@ -503,8 +943,36 @@ class ParameterManager:
         return self._pd_manager.get_varying_params()
 
     def display_pd_params(self) -> None:
-        """Display polydispersity parameter values and settings."""
-        self._pd_manager.display()
+        """Display polydispersity parameter values and settings.
+
+        On the ``set_models`` path the canonical prefixed names are translated
+        to their user-facing aliases for display.
+        """
+        if not self._canonical_to_alias:
+            self._pd_manager.display()
+            return
+
+        if not self._pd_manager.param_names:
+            print('No polydisperse parameters available for this model.')
+            return
+
+        status = 'ENABLED' if self._pd_manager.enabled else 'DISABLED'
+        print(f'\n{"=" * 90}')
+        print(f'Polydispersity Status: {status}')
+        print(f'{"=" * 90}')
+        print(
+            f'{"Parameter":<20} {"Width":<10} {"N Points":<10} {"N Sigma":<10} {"Type":<12} {"Vary":<8}'
+        )
+        print(f'{"-" * 90}')
+        for param_name in self._pd_manager.param_names:
+            pd_config = self._pd_manager.params[param_name]
+            display_name = self._canonical_to_alias.get(param_name, param_name)
+            vary_str = '✓' if pd_config.get('vary', False) else '✗'
+            print(
+                f'{display_name:<20} {pd_config["pd"]:<10.4g} {pd_config["pd_n"]:<10} '
+                f'{pd_config["pd_nsigma"]:<10.4g} {pd_config["pd_type"]:<12} {vary_str:<8}'
+            )
+        print(f'{"=" * 90}\n')
 
     def backup_pd_state(self) -> None:
         """Backup current polydispersity state (used before applying structure factor)."""
@@ -528,6 +996,14 @@ class ParameterManager:
         self.params = {}
         self.model_name = None
         self._sf_manager.clear()
+
+        # Reset composite-model state
+        self._components = []
+        self._links = {}
+        self._alias_to_canonical = {}
+        self._canonical_to_alias = {}
+        self._shared_to_canonicals = {}
+        self._suppressed_aliases = set()
 
         # Reset polydispersity state
         self._pd_manager.clear()

--- a/src/sans_fitter/parameter_manager.py
+++ b/src/sans_fitter/parameter_manager.py
@@ -118,8 +118,6 @@ class ParameterManager:
         self._alias_to_canonical: dict[str, str] = {}
         self._canonical_to_alias: dict[str, str] = {}
         self._shared_to_canonicals: dict[str, list[str]] = {}
-        # Aliases suppressed from the user-facing params dict (shared= entries).
-        self._suppressed_aliases: set[str] = set()
 
     @property
     def _structure_factor_name(self) -> Optional[str]:
@@ -550,7 +548,6 @@ class ParameterManager:
 
         # Re-key the user-facing params dict to alias names.
         new_params: dict[str, dict[str, Any]] = {}
-        suppressed: set[str] = set()
         shared_canonical_set = {
             canonical for canonicals in shared_to_canonicals.values() for canonical in canonicals
         }
@@ -559,12 +556,11 @@ class ParameterManager:
                 new_params[canonical] = info  # global scale/background
                 continue
             if canonical in shared_canonical_set:
+                # The prefixed alias of a shared parameter is suppressed: only
+                # the shared name appears in the user-facing params dict.
                 shared_name = canonical_to_alias[canonical]
                 if shared_to_canonicals[shared_name][0] == canonical:
                     new_params[shared_name] = info
-                # Suppress the prefixed alias of a shared parameter.
-                prefixed_alias = next(a for a, c in alias_to_canonical.items() if c == canonical)
-                suppressed.add(prefixed_alias)
             else:
                 new_params[canonical_to_alias[canonical]] = info
 
@@ -573,7 +569,6 @@ class ParameterManager:
         self._alias_to_canonical = alias_to_canonical
         self._canonical_to_alias = canonical_to_alias
         self._shared_to_canonicals = shared_to_canonicals
-        self._suppressed_aliases = suppressed
 
     def _resolve_canonical(self, name: str) -> str:
         """Map an alias (or canonical) name to its canonical sasmodels name."""
@@ -979,31 +974,7 @@ class ParameterManager:
         On the ``set_models`` path the canonical prefixed names are translated
         to their user-facing aliases for display.
         """
-        if not self._canonical_to_alias:
-            self._pd_manager.display()
-            return
-
-        if not self._pd_manager.param_names:
-            print('No polydisperse parameters available for this model.')
-            return
-
-        status = 'ENABLED' if self._pd_manager.enabled else 'DISABLED'
-        print(f'\n{"=" * 90}')
-        print(f'Polydispersity Status: {status}')
-        print(f'{"=" * 90}')
-        print(
-            f'{"Parameter":<20} {"Width":<10} {"N Points":<10} {"N Sigma":<10} {"Type":<12} {"Vary":<8}'
-        )
-        print(f'{"-" * 90}')
-        for param_name in self._pd_manager.param_names:
-            pd_config = self._pd_manager.params[param_name]
-            display_name = self._canonical_to_alias.get(param_name, param_name)
-            vary_str = '✓' if pd_config.get('vary', False) else '✗'
-            print(
-                f'{display_name:<20} {pd_config["pd"]:<10.4g} {pd_config["pd_n"]:<10} '
-                f'{pd_config["pd_nsigma"]:<10.4g} {pd_config["pd_type"]:<12} {vary_str:<8}'
-            )
-        print(f'{"=" * 90}\n')
+        self._pd_manager.display(name_map=self._canonical_to_alias or None)
 
     def backup_pd_state(self) -> None:
         """Backup current polydispersity state (used before applying structure factor)."""
@@ -1034,7 +1005,6 @@ class ParameterManager:
         self._alias_to_canonical = {}
         self._canonical_to_alias = {}
         self._shared_to_canonicals = {}
-        self._suppressed_aliases = set()
 
         # Reset polydispersity state
         self._pd_manager.clear()

--- a/src/sans_fitter/plotting.py
+++ b/src/sans_fitter/plotting.py
@@ -29,6 +29,20 @@ POSTERIOR_PREDICTIVE_INTERVAL_TRACE_NAME = '95% credible interval'
 MARGINAL_DENSITY_TRACE_NAME = 'Marginal density'
 MEASURED_TRACE_NAME = 'Measured'
 
+# Qualitative color cycle for per-component curves (plotly's default palette).
+COMPONENT_CURVE_COLORS = [
+    '#636efa',
+    '#ef553b',
+    '#00cc96',
+    '#ab63fa',
+    '#ffa15a',
+    '#19d3f3',
+    '#ff6692',
+    '#b6e880',
+    '#ff97ff',
+    '#fecb52',
+]
+
 
 def _running_in_notebook() -> bool:
     """Return True when executing inside a Jupyter kernel.
@@ -67,10 +81,14 @@ def plot_fit(
     show_residuals: bool = True,
     log_scale: bool = True,
     show: bool | None = None,
+    show_components: bool = False,
 ) -> go.Figure:
     """Plot experimental data and, when available, the fitted model curve.
 
     Args:
+        show_components: When True and the fit result carries per-component
+            curves ('+' mixture models), draw one dashed curve per component.
+            A no-op when no component curves are available.
         show: If True, call fig.show(); if False, only return the figure.
             Default (None) shows the figure except in Jupyter, where the
             returned figure is rendered by the notebook itself.
@@ -165,11 +183,33 @@ def plot_fit(
         line={'color': 'red', 'width': 2},
     )
 
+    component_traces = []
+    if show_components and fit_result.artifacts.component_curves:
+        for i, (label, curve) in enumerate(fit_result.artifacts.component_curves.items()):
+            curve = np.asarray(curve)
+            if len(curve) != len(q):
+                continue
+            component_traces.append(
+                go.Scatter(
+                    x=q,
+                    y=curve,
+                    mode='lines',
+                    name=label,
+                    line={
+                        'dash': 'dash',
+                        'width': 1.5,
+                        'color': COMPONENT_CURVE_COLORS[i % len(COMPONENT_CURVE_COLORS)],
+                    },
+                )
+            )
+
     if show_residuals:
         fig.add_trace(data_trace, row=1, col=1)
         if excluded_trace is not None:
             fig.add_trace(excluded_trace, row=1, col=1)
         fig.add_trace(fit_trace, row=1, col=1)
+        for trace in component_traces:
+            fig.add_trace(trace, row=1, col=1)
         fig.add_trace(
             go.Scatter(
                 x=q,
@@ -203,6 +243,8 @@ def plot_fit(
         if excluded_trace is not None:
             fig.add_trace(excluded_trace)
         fig.add_trace(fit_trace)
+        for trace in component_traces:
+            fig.add_trace(trace)
         fig.update_xaxes(
             title_text='Q (Å⁻¹)',
             type='log' if log_scale else 'linear',

--- a/src/sans_fitter/polydispersity.py
+++ b/src/sans_fitter/polydispersity.py
@@ -152,7 +152,13 @@ class PolydispersityManager:
             if pd_config.get('vary', False)
         ]
 
-    def display(self) -> None:
+    def display(self, name_map: Optional[dict[str, str]] = None) -> None:
+        """Print the polydispersity table.
+
+        Args:
+            name_map: Optional canonical-to-display name translation, used on
+                the ``set_models`` path where parameters carry alias names.
+        """
         if not self._param_names:
             print('No polydisperse parameters available for this model.')
             return
@@ -162,15 +168,16 @@ class PolydispersityManager:
         print(f'Polydispersity Status: {status}')
         print(f'{"=" * 90}')
         print(
-            f'{"Parameter":<15} {"Width":<10} {"N Points":<10} {"N Sigma":<10} {"Type":<12} {"Vary":<8}'
+            f'{"Parameter":<20} {"Width":<10} {"N Points":<10} {"N Sigma":<10} {"Type":<12} {"Vary":<8}'
         )
         print(f'{"-" * 90}')
 
         for param_name in self._param_names:
             pd_config = self._params[param_name]
+            display_name = (name_map or {}).get(param_name, param_name)
             vary_str = '✓' if pd_config.get('vary', False) else '✗'
             print(
-                f'{param_name:<15} {pd_config["pd"]:<10.4g} {pd_config["pd_n"]:<10} '
+                f'{display_name:<20} {pd_config["pd"]:<10.4g} {pd_config["pd_n"]:<10} '
                 f'{pd_config["pd_nsigma"]:<10.4g} {pd_config["pd_type"]:<12} {vary_str:<8}'
             )
         print(f'{"=" * 90}\n')

--- a/src/sans_fitter/results.py
+++ b/src/sans_fitter/results.py
@@ -125,6 +125,10 @@ class FitArtifacts:
     posterior: Optional[PosteriorSummary] = None
     posterior_data: Any = None
     posterior_model_eval: Any = None
+    # Per-component curves for '+' mixture models: label -> I(q) evaluated on
+    # the same fit_index points as fitted_curve. None for atomic models and
+    # '*' mixtures (where part curves would not stack to the total).
+    component_curves: Optional[dict[str, np.ndarray]] = None
 
 
 @dataclass(slots=True)

--- a/src/sans_fitter/sans_fitter.py
+++ b/src/sans_fitter/sans_fitter.py
@@ -8,7 +8,8 @@ optimization engines (BUMPS, LMFit) with any model from the SasModels library.
 import difflib
 import re
 import warnings
-from typing import Any, Literal, Optional, Sequence
+from collections.abc import Sequence
+from typing import Any, Literal, Optional
 
 import numpy as np
 from plotly.graph_objects import Figure
@@ -793,7 +794,7 @@ class SANSFitter:
 
         canonical_values = self._param_manager.get_canonical_param_values()
         global_scale = canonical_values.get('scale', 1.0)
-        background = canonical_values.get('background', 0.0)
+        canonical_values.get('background', 0.0)
 
         # Active polydispersity settings, keyed by canonical base names.
         pd_settings: dict[str, dict[str, Any]] = {}

--- a/src/sans_fitter/sans_fitter.py
+++ b/src/sans_fitter/sans_fitter.py
@@ -906,6 +906,8 @@ class SANSFitter:
 
         Raises:
             ValueError: If data or model not loaded, or invalid engine
+            NotImplementedError: If a composite model or parameter links are
+                used with an engine other than 'bumps'.
         """
         if self.data is None:
             raise ValueError('No data loaded. Use load_data() first.')
@@ -1065,6 +1067,8 @@ class SANSFitter:
 
         Raises:
             ValueError: If data or model is not loaded, or no parameter varies.
+            NotImplementedError: If a composite model or parameter links are
+                used — the DREAM path does not support them yet.
         """
         if self.data is None:
             raise ValueError('No data loaded. Use load_data() first.')

--- a/src/sans_fitter/sans_fitter.py
+++ b/src/sans_fitter/sans_fitter.py
@@ -5,8 +5,10 @@ This module provides a unified interface for fitting SANS data using different
 optimization engines (BUMPS, LMFit) with any model from the SasModels library.
 """
 
+import difflib
+import re
 import warnings
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, Sequence
 
 import numpy as np
 from plotly.graph_objects import Figure
@@ -28,7 +30,7 @@ from .fitting import (
     fit_bumps_dream,
     fit_scipy,
 )
-from .fitting.base import extract_fit_index
+from .fitting.base import extract_fit_index, pd_is_active
 from .parameter_manager import ParameterManager
 from .plotting import DEFAULT_POSTERIOR_PREDICTIVE_DRAWS, plot_fit
 from .results import FitArtifacts, FitResultContract, PosteriorSummary, save_fit_result
@@ -47,6 +49,32 @@ def get_all_models() -> list[str]:
     except Exception as e:
         print(f'Error fetching models: {str(e)}')
         return []
+
+
+def _validate_model_expression(model_name: str) -> None:
+    """Validate every atomic model name in a (possibly composite) expression.
+
+    Splits on top-level ``+``/``*`` and on ``@`` (product parts), checking each
+    atomic name against ``sasmodels.core.list_models()``. Unknown names raise a
+    ``ValueError`` with a nearest-match suggestion.
+    """
+    available = set(core.list_models())
+    for part in re.split(r'[+*]', model_name):
+        part = part.strip()
+        if not part:
+            raise ValueError(f"Invalid model expression '{model_name}': empty component.")
+        for atomic in part.split('@'):
+            atomic = atomic.strip()
+            if not atomic:
+                raise ValueError(
+                    f"Invalid model expression '{model_name}': empty component."
+                )
+            if atomic not in available:
+                suggestions = difflib.get_close_matches(atomic, available, n=1)
+                hint = f" Did you mean '{suggestions[0]}'?" if suggestions else ''
+                raise ValueError(
+                    f"Unknown model '{atomic}' in '{model_name}'.{hint}"
+                )
 
 
 LMFIT_AVAILABLE = SCIPY_AVAILABLE
@@ -243,20 +271,32 @@ class SANSFitter:
         """
         Set the SANS model to use for fitting.
 
+        Accepts both single models and composite expressions understood by
+        sasmodels: ``'dab+peak_lorentz'`` (sum mixture), ``'modelA*modelB'``
+        (product mixture), and ``'sphere@hardsphere'`` (form factor with
+        structure factor). Every atomic model name in the expression is
+        validated against the sasmodels model list before loading, with a
+        nearest-match suggestion for unknown names.
+
         This resets any active structure factor to ensure a clean state.
 
         Args:
-            model_name: Name of the model from SasModels (e.g., 'cylinder', 'sphere')
+            model_name: Name of the model from SasModels (e.g., 'cylinder',
+                'sphere', 'dab+peak_lorentz')
             platform: Computation platform ('cpu' or 'opencl')
 
         Raises:
             ValueError: If the model name is not valid
         """
+        _validate_model_expression(model_name)
+
         try:
             # Force CPU platform to avoid OpenCL issues
             self.kernel = load_model(model_name, dtype='single', platform='dll')
 
-            # Initialize parameters via ParameterManager
+            # Initialize parameters via ParameterManager. Components are
+            # derived from the kernel's composition tree, not the expression
+            # string (robust against nested mixture plugins).
             self._param_manager.initialize_from_kernel(self.kernel, model_name)
 
             print(f"✓ Model '{model_name}' loaded successfully")
@@ -264,6 +304,176 @@ class SANSFitter:
 
         except Exception as e:
             raise ValueError(f"Failed to load model '{model_name}': {str(e)}") from e
+
+    def set_models(
+        self,
+        *model_names: str,
+        operation: str = '+',
+        shared: Sequence[str] = (),
+        **monikers: str,
+    ) -> None:
+        """
+        Combine multiple models against the current dataset.
+
+        The friendly-name entry point for composite models. Parameters are
+        exposed with model-name (or moniker) prefixes instead of sasmodels'
+        ``A_``/``B_`` prefixes, e.g. ``dab_cor_length`` instead of
+        ``A_cor_length``.
+
+        Args:
+            *model_names: Model names, positionally. Each may itself contain
+                ``@`` to apply a structure factor to one part (e.g.
+                ``'sphere@hardsphere'``).
+            operation: How to combine the models: ``'+'`` (sum mixture, the
+                default) or ``'*'`` (product mixture).
+            shared: Unprefixed parameter names that must exist in at least 2
+                components. Each becomes a single unprefixed parameter driving
+                every component that has it (e.g. ``shared=['sld']``).
+                Polydispersity configuration stays per-component under the
+                prefixed names.
+            **monikers: Components given as ``moniker=model_name`` keyword
+                arguments, for long model names, duplicates, or physics
+                labels (e.g. ``small='sphere', large='sphere'``).
+
+        Example:
+            >>> fitter.set_models('dab', 'peak_lorentz')
+            >>> fitter.set_param('dab_cor_length', value=50, vary=True)
+            >>> fitter.set_models(small='sphere', large='sphere', shared=['sld'])
+
+        Raises:
+            ValueError: If fewer than 2 models are given, the operation is
+                invalid, a moniker is invalid, a shared name is missing from
+                enough components, or the generated alias names collide.
+        """
+        if operation not in ('+', '*'):
+            raise ValueError(f"Invalid operation '{operation}'. Use '+' or '*'.")
+
+        components: list[tuple[str, str]] = []  # (moniker, model_name)
+        for name in model_names:
+            # Positional moniker defaults to the model name; for product
+            # entries ('sphere@hardsphere') use the form-factor part so the
+            # moniker stays a valid identifier.
+            moniker = name if name.isidentifier() else name.split('@')[0]
+            components.append((moniker, name))
+        for moniker, name in monikers.items():
+            components.append((moniker, name))
+
+        if len(components) < 2:
+            raise ValueError(
+                'set_models() requires at least 2 models. '
+                "For a single model use set_model('name')."
+            )
+
+        # Validate monikers: valid identifiers and not reserved names.
+        # Positional model names may repeat (they get auto-suffixed below);
+        # keyword monikers must be unique among themselves.
+        reserved = {'scale', 'background'} | set(shared)
+        for moniker, _name in components:
+            if not moniker.isidentifier():
+                raise ValueError(
+                    f"Component name '{moniker}' is not a valid identifier. "
+                    'Use keyword monikers for non-identifier model names.'
+                )
+            if moniker in reserved:
+                raise ValueError(
+                    f"Component name '{moniker}' is reserved "
+                    "(collides with 'scale', 'background', or a shared name)."
+                )
+        keyword_monikers = [moniker for moniker, _name in components[len(model_names) :]]
+        if len(set(keyword_monikers)) != len(keyword_monikers):
+            raise ValueError('Duplicate keyword monikers are not allowed.')
+
+        # Duplicate positional model names auto-suffix their monikers
+        # (sphere1_, sphere2_); keyword monikers are the recommended spelling
+        # for that case.
+        positional_counts: dict[str, int] = {}
+        for name in model_names:
+            positional_counts[name] = positional_counts.get(name, 0) + 1
+        duplicate_names = {name for name, count in positional_counts.items() if count > 1}
+
+        resolved: list[tuple[str, str]] = []
+        dup_counters: dict[str, int] = {}
+        for moniker, name in components:
+            if moniker == name and name in duplicate_names:
+                dup_counters[name] = dup_counters.get(name, 0) + 1
+                resolved.append((f'{name}{dup_counters[name]}', name))
+            else:
+                resolved.append((moniker, name))
+        components = resolved
+
+        # Re-check uniqueness after auto-suffixing (a generated suffix could
+        # collide with an explicit moniker).
+        all_monikers = [moniker for moniker, _name in components]
+        if len(set(all_monikers)) != len(all_monikers):
+            raise ValueError(
+                'Component names collide after auto-suffixing duplicates: '
+                f'{all_monikers}. Use distinct keyword monikers.'
+            )
+
+        # Delegate loading/validation to set_model using canonical syntax.
+        expression = operation.join(name for _moniker, name in components)
+        self.set_model(expression)
+
+        # Register the friendly-name alias layer. register_aliases raises on
+        # shared-name or alias-collision problems (detected by building the
+        # full alias map, not by ad-hoc string rules).
+        self._param_manager.register_aliases(components, list(shared))
+
+        print(f'✓ Combined {len(components)} models: {expression}')
+        print(f'  Components: {", ".join(m for m, _n in components)}')
+        if shared:
+            print(f'  Shared parameters: {", ".join(shared)}')
+        print(f'  Available parameters: {len(self._param_manager.params)}')
+
+    def link_params(self, name: str, to: str) -> None:
+        """
+        Create an equality link between two parameters.
+
+        The follower (*name*) is forced to ``vary=False`` and mirrors the
+        target's (*to*) value at all times — before, during, and after the
+        fit. Links are equality-only; no expressions. Works for any pair of
+        parameters, including cross-component ones (``'large_sld'`` following
+        ``'small_sld'``) and differently named ones.
+
+        Args:
+            name: The follower parameter name.
+            to: The target parameter name.
+
+        Raises:
+            KeyError: If either name does not exist.
+            ValueError: On self-links, link chains, or conflicting links.
+        """
+        self._param_manager.link_params(name, to)
+        print(f'✓ Linked {name} → {to}')
+
+    def unlink_params(self, name: str) -> None:
+        """
+        Remove an equality link, restoring the follower's independence.
+
+        Args:
+            name: The follower parameter name.
+
+        Raises:
+            KeyError: If the name does not exist.
+            ValueError: If the parameter is not linked.
+        """
+        self._param_manager.unlink_params(name)
+        print(f'✓ Unlinked {name}')
+
+    def get_links(self) -> dict[str, str]:
+        """Return the active parameter equality links (follower -> target)."""
+        return self._param_manager.get_links()
+
+    def get_components(self) -> list[tuple[str, str, str]]:
+        """
+        Return the composite-model components.
+
+        Returns:
+            List of ``(prefix, moniker, part_model_name)`` triples, e.g.
+            ``[('A', 'dab', 'dab'), ('B', 'peak_lorentz', 'peak_lorentz')]``.
+            Empty for atomic models.
+        """
+        return self._param_manager.get_components()
 
     # =========================================================================
     # Property accessors for backward compatibility
@@ -352,6 +562,15 @@ class SANSFitter:
         """
         if self.kernel is None or self.model_name is None:
             raise ValueError('No form factor model loaded. Use set_model() first.')
+
+        if self._param_manager.get_components():
+            raise ValueError(
+                'Cannot apply a structure factor to a composite model. '
+                "The expression '(modelA+modelB)@sf' cannot be expressed in "
+                'sasmodels, and naive concatenation would be parsed as '
+                "'modelA + (modelB@sf)'. Apply the structure factor to one "
+                "part instead, e.g. set_models('sphere@hardsphere', 'peak_lorentz')."
+            )
 
         # Validate structure factor name
         supported_sf = ['hardsphere', 'hayter_msa', 'squarewell', 'stickyhardsphere']
@@ -526,6 +745,20 @@ class SANSFitter:
         """Apply engine output to fitter state and return legacy-compatible results."""
         self._param_manager.apply_fitted_values(engine_output.fitted_values)
         self._fit_contract = engine_output.contract
+
+        # Translate engine result names (canonical) back to user-facing names
+        # so saved results and displays never expose A_/B_ on the set_models
+        # path (Boundary 2 of the alias layer).
+        self._fit_contract.parameters = {
+            self._param_manager.to_display_name(name): dict(info)
+            for name, info in self._fit_contract.parameters.items()
+        }
+
+        # Attach per-component curves for '+' mixture models (no-op otherwise).
+        component_curves = self._compute_component_curves()
+        if component_curves:
+            self._fit_contract.artifacts.component_curves = component_curves
+
         self.fit_result = self._fit_contract.to_legacy_dict()
         self._fitted_model = engine_output.runtime_model
 
@@ -541,6 +774,78 @@ class SANSFitter:
             print(posterior.format_summary())
 
         return self.fit_result
+
+    def _compute_component_curves(self) -> Optional[dict[str, np.ndarray]]:
+        """Compute per-component curves after a fit of a '+' mixture model.
+
+        Each component curve is ``scale · I_part(q, scale=part_scale,
+        background=0)`` — matching the mixture kernel's own computation — so
+        the component curves plus the background stack onto the total curve.
+
+        Returns None for atomic models and '*' mixtures (where part curves
+        would not stack to the total and would mislead when overlaid).
+        Evaluation happens on the same masked q-points as the total curve.
+        """
+        components = self._param_manager.get_components()
+        if not components:
+            return None
+
+        # '*' mixtures: part intensities multiply, so additive component
+        # curves are meaningless. Documented no-op.
+        operation = getattr(self.kernel.info, 'operation', '+')
+        if operation != '+':
+            return None
+
+        canonical_values = self._param_manager.get_canonical_param_values()
+        global_scale = canonical_values.get('scale', 1.0)
+        background = canonical_values.get('background', 0.0)
+
+        # Active polydispersity settings, keyed by canonical base names.
+        pd_settings: dict[str, dict[str, Any]] = {}
+        if self._param_manager.is_pd_enabled():
+            for base_param in self._param_manager.get_polydisperse_parameters():
+                pd_config = self._param_manager.polydisperse_params[base_param]
+                if pd_is_active(pd_config):
+                    pd_settings[base_param] = pd_config
+
+        curves: dict[str, np.ndarray] = {}
+        for prefix, moniker, part_name in components:
+            # Label: moniker, with the model name appended when they differ;
+            # on the raw-string path moniker == prefix ('A: dab').
+            if moniker == prefix and moniker != part_name:
+                label = f'{prefix}: {part_name}'
+            elif moniker != part_name:
+                label = f'{moniker} ({part_name})'
+            else:
+                label = moniker
+
+            part_kernel = load_model(part_name, dtype='single', platform='dll')
+            calculator = DirectModel(self.data, part_kernel)
+
+            # Map fitted values by stripping the component prefix; fold in
+            # active PD settings the same way the posterior evaluator does.
+            part_pars: dict[str, Any] = {}
+            prefix_marker = f'{prefix}_'
+            for canonical, value in canonical_values.items():
+                if canonical.startswith(prefix_marker):
+                    stripped = canonical[len(prefix_marker) :]
+                    part_pars[stripped] = value
+            # The part's own scale slot gets the component scale; background
+            # is excluded from component curves (shown implicitly in total).
+            part_scale = canonical_values.get(f'{prefix}_scale', 1.0)
+            part_pars['scale'] = part_scale
+            part_pars['background'] = 0.0
+            for base_param, pd_config in pd_settings.items():
+                if base_param.startswith(prefix_marker):
+                    stripped = base_param[len(prefix_marker) :]
+                    part_pars[f'{stripped}_pd'] = pd_config['pd']
+                    part_pars[f'{stripped}_pd_n'] = pd_config['pd_n']
+                    part_pars[f'{stripped}_pd_nsigma'] = pd_config['pd_nsigma']
+                    part_pars[f'{stripped}_pd_type'] = pd_config['pd_type']
+
+            curves[label] = global_scale * np.asarray(calculator(**part_pars))
+
+        return curves
 
     def _get_active_fit_contract(self) -> Optional[FitResultContract]:
         """Return the active fit contract, adapting legacy runtime state if needed."""
@@ -605,6 +910,8 @@ class SANSFitter:
         if engine not in ('bumps', 'lmfit'):
             raise ValueError(f"Unknown engine '{engine}'. Use 'bumps' or 'lmfit'.")
 
+        self._check_composite_engine_support(engine)
+        self._check_scale_degeneracy()
         self._check_fit_uncertainties(engine)
 
         if engine == 'bumps':
@@ -612,6 +919,50 @@ class SANSFitter:
         if not LMFIT_AVAILABLE:
             raise ValueError("scipy is not installed. Use 'bumps' engine or install scipy.")
         return self._fit_lmfit(method or 'leastsq', **kwargs)
+
+    def _check_composite_engine_support(self, engine: str) -> None:
+        """Gate composite models and parameter links to the bumps engine.
+
+        The scipy path would probably work for composites (DirectModel accepts
+        prefixed kwargs) but it is untested; failing loudly beats silently
+        unvalidated results. A model using shared= always presents non-empty
+        linked_params, so no separate gate is needed for it.
+        """
+        if engine == 'bumps':
+            return
+        snapshot = self._param_manager.snapshot_fit_state()
+        if snapshot.linked_params:
+            raise NotImplementedError(
+                "Parameter links are currently supported by the 'bumps' engine only."
+            )
+        if snapshot.components:
+            raise NotImplementedError(
+                "Composite models are currently supported by the 'bumps' engine only."
+            )
+
+    def _check_scale_degeneracy(self) -> None:
+        """Warn when the global scale and a component scale are both free.
+
+        Under a mixture, the total intensity is scale · Σ(part_scale · I_part);
+        varying both the global scale and any component scale is degenerate —
+        only their product is fitted.
+        """
+        varying = self._param_manager.get_varying_params()
+        if 'scale' not in varying:
+            return
+        component_scales = [
+            name
+            for name in varying
+            if name.endswith('_scale') and name != 'scale'
+        ]
+        if component_scales:
+            warnings.warn(
+                "Both the global 'scale' and component scale(s) "
+                f'{", ".join(component_scales)} are varying. Their product is '
+                'what the fit sees, so the split between them is degenerate. '
+                'Fix one of them.',
+                stacklevel=3,
+            )
 
     def _check_fit_uncertainties(self, engine: str) -> None:
         """Validate intensity uncertainties (dI) before fitting.
@@ -714,6 +1065,14 @@ class SANSFitter:
             raise ValueError('No data loaded. Use load_data() first.')
         if self.kernel is None:
             raise ValueError('No model loaded. Use set_model() first.')
+
+        snapshot = self._param_manager.snapshot_fit_state()
+        if snapshot.linked_params or snapshot.components:
+            raise NotImplementedError(
+                "Composite models and parameter links are currently supported "
+                "by the 'bumps' point-estimate engine only (fit(engine='bumps'))."
+            )
+        self._check_scale_degeneracy()
 
         engine_output = fit_bumps_dream(
             data=self.data,
@@ -866,6 +1225,7 @@ class SANSFitter:
         show_residuals: bool = True,
         log_scale: bool = True,
         show: bool | None = None,
+        show_components: bool = False,
     ) -> Figure:
         """
         Plot experimental data and fitted model.
@@ -877,6 +1237,9 @@ class SANSFitter:
                 return it. The default (None) displays the figure except in
                 Jupyter notebooks, where the returned figure is rendered by
                 the notebook itself (avoids showing the plot twice).
+            show_components: If True and the fitted model is a '+' mixture,
+                overlay one dashed curve per component (labelled by moniker).
+                A documented no-op for atomic models and '*' mixtures.
 
         Returns:
             Plotly Figure object
@@ -888,6 +1251,7 @@ class SANSFitter:
             show_residuals=show_residuals,
             log_scale=log_scale,
             show=show,
+            show_components=show_components,
         )
 
     def save_results(self, filename: str) -> None:

--- a/src/sans_fitter/sans_fitter.py
+++ b/src/sans_fitter/sans_fitter.py
@@ -66,15 +66,11 @@ def _validate_model_expression(model_name: str) -> None:
         for atomic in part.split('@'):
             atomic = atomic.strip()
             if not atomic:
-                raise ValueError(
-                    f"Invalid model expression '{model_name}': empty component."
-                )
+                raise ValueError(f"Invalid model expression '{model_name}': empty component.")
             if atomic not in available:
                 suggestions = difflib.get_close_matches(atomic, available, n=1)
                 hint = f" Did you mean '{suggestions[0]}'?" if suggestions else ''
-                raise ValueError(
-                    f"Unknown model '{atomic}' in '{model_name}'.{hint}"
-                )
+                raise ValueError(f"Unknown model '{atomic}' in '{model_name}'.{hint}")
 
 
 LMFIT_AVAILABLE = SCIPY_AVAILABLE
@@ -360,8 +356,7 @@ class SANSFitter:
 
         if len(components) < 2:
             raise ValueError(
-                'set_models() requires at least 2 models. '
-                "For a single model use set_model('name')."
+                "set_models() requires at least 2 models. For a single model use set_model('name')."
             )
 
         # Validate monikers: valid identifiers and not reserved names.
@@ -950,11 +945,7 @@ class SANSFitter:
         varying = self._param_manager.get_varying_params()
         if 'scale' not in varying:
             return
-        component_scales = [
-            name
-            for name in varying
-            if name.endswith('_scale') and name != 'scale'
-        ]
+        component_scales = [name for name in varying if name.endswith('_scale') and name != 'scale']
         if component_scales:
             warnings.warn(
                 "Both the global 'scale' and component scale(s) "
@@ -1069,7 +1060,7 @@ class SANSFitter:
         snapshot = self._param_manager.snapshot_fit_state()
         if snapshot.linked_params or snapshot.components:
             raise NotImplementedError(
-                "Composite models and parameter links are currently supported "
+                'Composite models and parameter links are currently supported '
                 "by the 'bumps' point-estimate engine only (fit(engine='bumps'))."
             )
         self._check_scale_degeneracy()

--- a/src/sans_fitter/sans_fitter.py
+++ b/src/sans_fitter/sans_fitter.py
@@ -53,11 +53,15 @@ def get_all_models() -> list[str]:
 
 
 def _validate_model_expression(model_name: str) -> None:
-    """Validate every atomic model name in a (possibly composite) expression.
+    """Validate atomic model names in a (possibly composite) expression.
 
-    Splits on top-level ``+``/``*`` and on ``@`` (product parts), checking each
-    atomic name against ``sasmodels.core.list_models()``. Unknown names raise a
-    ``ValueError`` with a nearest-match suggestion.
+    Splits on top-level ``+``/``*`` and on ``@`` (product parts). Only parts
+    that look like plain model identifiers are checked against
+    ``sasmodels.core.list_models()``; unknown names raise a ``ValueError``
+    with a nearest-match suggestion. Anything else — custom plugin-model
+    paths, parenthesized or scaled expressions — is passed through for
+    ``sasmodels.core.load_model`` to accept or reject, since it is the
+    authority on those forms.
     """
     available = set(core.list_models())
     for part in re.split(r'[+*]', model_name):
@@ -68,6 +72,8 @@ def _validate_model_expression(model_name: str) -> None:
             atomic = atomic.strip()
             if not atomic:
                 raise ValueError(f"Invalid model expression '{model_name}': empty component.")
+            if not re.fullmatch(r'[A-Za-z_]\w*', atomic):
+                continue  # custom path or expression form — load_model decides
             if atomic not in available:
                 suggestions = difflib.get_close_matches(atomic, available, n=1)
                 hint = f" Did you mean '{suggestions[0]}'?" if suggestions else ''
@@ -340,7 +346,11 @@ class SANSFitter:
         Raises:
             ValueError: If fewer than 2 models are given, the operation is
                 invalid, a moniker is invalid, a shared name is missing from
-                enough components, or the generated alias names collide.
+                enough components, the generated alias names collide, or an
+                entry expands to more than one kernel component (e.g. a
+                nested ``'+'``/``'*'`` expression) — each entry must be a
+                single component so monikers map 1:1; use the raw
+                ``set_model('a+b')`` string path for nested expressions.
         """
         if operation not in ('+', '*'):
             raise ValueError(f"Invalid operation '{operation}'. Use '+' or '*'.")
@@ -794,7 +804,6 @@ class SANSFitter:
 
         canonical_values = self._param_manager.get_canonical_param_values()
         global_scale = canonical_values.get('scale', 1.0)
-        canonical_values.get('background', 0.0)
 
         # Active polydispersity settings, keyed by canonical base names.
         pd_settings: dict[str, dict[str, Any]] = {}
@@ -945,6 +954,10 @@ class SANSFitter:
         """
         varying = self._param_manager.get_varying_params()
         if 'scale' not in varying:
+            return
+        # Atomic models can expose their own *_scale parameters (broad_peak,
+        # gel_fit, ...) that are not mixture component scales.
+        if not self._param_manager.get_components():
             return
         component_scales = [name for name in varying if name.endswith('_scale') and name != 'scale']
         if component_scales:

--- a/src/sans_fitter/structure_factor.py
+++ b/src/sans_fitter/structure_factor.py
@@ -4,6 +4,27 @@ from typing import Any, Optional
 import numpy as np
 
 
+def default_parameter_bounds(default: float, limits: tuple[float, float]) -> tuple[float, float]:
+    """Finite, sign-permissive fallback bounds for a kernel parameter.
+
+    Finite declared limits are kept as-is. Each infinite side of a
+    ``(-inf, inf)``-style declaration is replaced by a range derived from the
+    default value: ``default ± max(10·|default|, 1.0)``, with the lower side
+    additionally capped at 0 so SLD-like parameters can go negative. This
+    guarantees a non-degenerate range even for zero-default parameters.
+
+    Note: this is a deliberate policy — parameters whose old fallback produced
+    ``[0, 10·default]`` now get sign-permissive ranges; users who relied on
+    the implicit positivity should set explicit bounds via ``set_param``.
+    """
+    lo, hi = limits
+    if not np.isfinite(lo):
+        lo = min(0.0, default - max(10 * abs(default), 1.0))
+    if not np.isfinite(hi):
+        hi = default + max(10 * abs(default), 1.0)
+    return lo, hi
+
+
 class StructureFactorManager:
     """Manage structure factor state and form-factor parameter backups."""
 
@@ -70,10 +91,11 @@ class StructureFactorManager:
             if param.name in self._form_factor_params:
                 new_params[param.name] = dict(self._form_factor_params[param.name])
             else:
+                lo, hi = default_parameter_bounds(param.default, param.limits)
                 new_params[param.name] = {
                     'value': param.default,
-                    'min': param.limits[0] if param.limits[0] > -np.inf else 0,
-                    'max': param.limits[1] if param.limits[1] < np.inf else param.default * 10,
+                    'min': lo,
+                    'max': hi,
                     'vary': False,
                     'description': param.description,
                 }

--- a/tests/test_composite_models.py
+++ b/tests/test_composite_models.py
@@ -60,13 +60,9 @@ class TestCompositeLoading(unittest.TestCase):
         # Same shape (flat dict, same schema), differing only in keys.
         self.assertEqual(len(raw.params), len(builder.params))
         for info in raw.params.values():
-            self.assertEqual(
-                set(info.keys()), {'value', 'min', 'max', 'vary', 'description'}
-            )
+            self.assertEqual(set(info.keys()), {'value', 'min', 'max', 'vary', 'description'})
         for info in builder.params.values():
-            self.assertEqual(
-                set(info.keys()), {'value', 'min', 'max', 'vary', 'description'}
-            )
+            self.assertEqual(set(info.keys()), {'value', 'min', 'max', 'vary', 'description'})
 
         self.assertIn('A_cor_length', raw.params)
         self.assertIn('B_peak_pos', raw.params)
@@ -77,9 +73,7 @@ class TestCompositeLoading(unittest.TestCase):
         raw = SANSFitter()
         raw.set_data(make_composite_data())
         raw.set_model('dab+peak_lorentz')
-        self.assertEqual(
-            raw.get_components(), [('A', 'A', 'dab'), ('B', 'B', 'peak_lorentz')]
-        )
+        self.assertEqual(raw.get_components(), [('A', 'A', 'dab'), ('B', 'B', 'peak_lorentz')])
 
         builder = SANSFitter()
         builder.set_data(make_composite_data())
@@ -228,8 +222,13 @@ class TestCompositeFitRoundTrip(unittest.TestCase):
 
     def setUp(self):
         truth = dict(
-            A_scale=10.0, A_cor_length=50.0, B_scale=5.0,
-            B_peak_pos=0.1, B_peak_hwhm=0.01, scale=1.0, background=0.01,
+            A_scale=10.0,
+            A_cor_length=50.0,
+            B_scale=5.0,
+            B_peak_pos=0.1,
+            B_peak_hwhm=0.01,
+            scale=1.0,
+            background=0.01,
         )
         self.truth = truth
         self.fitter = SANSFitter()
@@ -304,8 +303,13 @@ class TestComponentCurves(unittest.TestCase):
 
     def setUp(self):
         truth = dict(
-            A_scale=10.0, A_cor_length=50.0, B_scale=5.0,
-            B_peak_pos=0.1, B_peak_hwhm=0.01, scale=1.0, background=0.01,
+            A_scale=10.0,
+            A_cor_length=50.0,
+            B_scale=5.0,
+            B_peak_pos=0.1,
+            B_peak_hwhm=0.01,
+            scale=1.0,
+            background=0.01,
         )
         self.fitter = SANSFitter()
         self.fitter.set_data(make_composite_data(params=truth))
@@ -320,7 +324,9 @@ class TestComponentCurves(unittest.TestCase):
         self.assertEqual(set(curves.keys()), {'dab', 'peak_lorentz'})
 
         fit_index = self.fitter._fit_contract.artifacts.fit_index
-        n_fit = int(np.asarray(fit_index).sum()) if fit_index is not None else len(self.fitter.data.x)
+        n_fit = (
+            int(np.asarray(fit_index).sum()) if fit_index is not None else len(self.fitter.data.x)
+        )
         for curve in curves.values():
             self.assertEqual(len(curve), n_fit)
 
@@ -589,8 +595,13 @@ class TestCompositePlotting(unittest.TestCase):
 
     def _fit_composite(self):
         truth = dict(
-            A_scale=10.0, A_cor_length=50.0, B_scale=5.0,
-            B_peak_pos=0.1, B_peak_hwhm=0.01, scale=1.0, background=0.01,
+            A_scale=10.0,
+            A_cor_length=50.0,
+            B_scale=5.0,
+            B_peak_pos=0.1,
+            B_peak_hwhm=0.01,
+            scale=1.0,
+            background=0.01,
         )
         fitter = SANSFitter()
         fitter.set_data(make_composite_data(params=truth))

--- a/tests/test_composite_models.py
+++ b/tests/test_composite_models.py
@@ -546,6 +546,51 @@ class TestSharedParameters(unittest.TestCase):
         self.assertIn('sld', fitter.params)
 
 
+class TestSharedLinkInteraction(unittest.TestCase):
+    """shared= and link_params combine without canonical-level link chains.
+
+    snapshot_fit_state may only emit a depth-1 link graph — no target is
+    itself a follower — because the bumps engine aliases parameter objects
+    in dict order and relies on that invariant.
+    """
+
+    def setUp(self):
+        self.fitter = SANSFitter()
+        self.fitter.set_data(make_composite_data(expression='sphere+sphere'))
+        self.fitter.set_models(small='sphere', large='sphere', shared=['sld'])
+
+    def assert_chain_free(self, linked_params):
+        followers = set(linked_params)
+        targets = set(linked_params.values())
+        self.assertFalse(followers & targets, f'link chain in {linked_params}')
+
+    def test_linking_the_shared_follower_repoints_all_canonicals(self):
+        # 'sld' expands to A_sld/B_sld; linking it must re-point both to the
+        # new target instead of leaving B_sld -> A_sld -> A_radius.
+        self.fitter.link_params('sld', to='small_radius')
+        snap = self.fitter._param_manager.snapshot_fit_state()
+        self.assertEqual(snap.linked_params, {'A_sld': 'A_radius', 'B_sld': 'A_radius'})
+        self.assert_chain_free(snap.linked_params)
+
+    def test_linking_to_a_shared_target_uses_its_first_canonical(self):
+        self.fitter.link_params('small_radius', to='sld')
+        snap = self.fitter._param_manager.snapshot_fit_state()
+        self.assertEqual(snap.linked_params, {'B_sld': 'A_sld', 'A_radius': 'A_sld'})
+        self.assert_chain_free(snap.linked_params)
+
+    def test_chain_through_shared_rejected_in_both_orders(self):
+        self.fitter.link_params('large_radius', to='sld')
+        with self.assertRaises(ValueError):
+            self.fitter.link_params('sld', to='small_radius')
+
+        fitter2 = SANSFitter()
+        fitter2.set_data(make_composite_data(expression='sphere+sphere'))
+        fitter2.set_models(small='sphere', large='sphere', shared=['sld'])
+        fitter2.link_params('sld', to='small_radius')
+        with self.assertRaises(ValueError):
+            fitter2.link_params('large_radius', to='sld')
+
+
 class TestComponentCurvesAgainstIntermediates(unittest.TestCase):
     """Dev-only validation against sasmodels' private MixtureKernel API.
 

--- a/tests/test_composite_models.py
+++ b/tests/test_composite_models.py
@@ -1,0 +1,629 @@
+"""Tests for composite (multi-model) support — issue #46.
+
+Covers the design in 46_COMPOSITE_MODELS.md: hardened string syntax, the
+friendly set_models() builder, equality links, shared= parameters, the alias
+layer, bounds policy, component curves, polydispersity routing, engine
+gating, and plotting.
+"""
+
+import os
+import unittest
+import warnings
+
+import numpy as np
+from sasdata.dataloader.data_info import Data1D
+from sasmodels.core import load_model
+from sasmodels.direct_model import DirectModel
+
+from sans_fitter import SANSFitter
+
+
+def make_composite_data(
+    expression='dab+peak_lorentz',
+    params=None,
+    num_points=40,
+    noise=0.0,
+    seed=42,
+):
+    """Simulate data from a composite model and return a fit-ready Data1D."""
+    q = np.linspace(0.005, 0.3, num_points)
+    data = Data1D(x=q, y=np.ones_like(q), dy=np.full_like(q, 0.05))
+    data.qmin, data.qmax = q.min(), q.max()
+    kernel = load_model(expression, dtype='single', platform='dll')
+    defaults = dict(scale=1.0, background=0.01)
+    if params:
+        defaults.update(params)
+    y = np.asarray(DirectModel(data, kernel)(**defaults))
+    if noise > 0:
+        rng = np.random.default_rng(seed)
+        y = y + rng.normal(0, noise, size=y.shape)
+    data.y = y
+    return data
+
+
+class TestCompositeLoading(unittest.TestCase):
+    """Test 1: loading and parameter discovery for both paths."""
+
+    def setUp(self):
+        self.fitter = SANSFitter()
+        self.fitter.set_data(make_composite_data())
+
+    def test_raw_and_builder_paths_same_shape(self):
+        raw = SANSFitter()
+        raw.set_data(make_composite_data())
+        raw.set_model('dab+peak_lorentz')
+
+        builder = SANSFitter()
+        builder.set_data(make_composite_data())
+        builder.set_models('dab', 'peak_lorentz')
+
+        # Same shape (flat dict, same schema), differing only in keys.
+        self.assertEqual(len(raw.params), len(builder.params))
+        for info in raw.params.values():
+            self.assertEqual(
+                set(info.keys()), {'value', 'min', 'max', 'vary', 'description'}
+            )
+        for info in builder.params.values():
+            self.assertEqual(
+                set(info.keys()), {'value', 'min', 'max', 'vary', 'description'}
+            )
+
+        self.assertIn('A_cor_length', raw.params)
+        self.assertIn('B_peak_pos', raw.params)
+        self.assertIn('dab_cor_length', builder.params)
+        self.assertIn('peak_lorentz_peak_pos', builder.params)
+
+    def test_get_components_triples(self):
+        raw = SANSFitter()
+        raw.set_data(make_composite_data())
+        raw.set_model('dab+peak_lorentz')
+        self.assertEqual(
+            raw.get_components(), [('A', 'A', 'dab'), ('B', 'B', 'peak_lorentz')]
+        )
+
+        builder = SANSFitter()
+        builder.set_data(make_composite_data())
+        builder.set_models('dab', 'peak_lorentz')
+        self.assertEqual(
+            builder.get_components(),
+            [('A', 'dab', 'dab'), ('B', 'peak_lorentz', 'peak_lorentz')],
+        )
+
+    def test_atomic_model_has_no_components(self):
+        fitter = SANSFitter()
+        fitter.set_data(make_composite_data())
+        fitter.set_model('sphere')
+        self.assertEqual(fitter.get_components(), [])
+
+    def test_precedence_product_binds_tightest(self):
+        # sphere@hardsphere+peak_lorentz must parse as
+        # (sphere@hardsphere) + peak_lorentz.
+        fitter = SANSFitter()
+        fitter.set_data(make_composite_data())
+        fitter.set_models('sphere@hardsphere', 'peak_lorentz')
+        comps = fitter.get_components()
+        self.assertEqual(comps[0][0], 'A')
+        self.assertEqual(comps[0][2], 'sphere@hardsphere')
+        # The product part's parameters carry the A_ prefix, aliased via the
+        # form-factor-derived moniker ('sphere').
+        self.assertIn('sphere_volfraction', fitter.params)
+        # Composition root is a mixture whose first part is a product.
+        self.assertEqual(fitter.kernel.info.composition[0], 'mixture')
+        first_part = fitter.kernel.info.composition[1][0]
+        self.assertEqual(first_part.composition[0], 'product')
+
+
+class TestCompositeValidation(unittest.TestCase):
+    """Test 2: validation of model expressions and set_models arguments."""
+
+    def setUp(self):
+        self.fitter = SANSFitter()
+        self.fitter.set_data(make_composite_data())
+
+    def test_unknown_part_name_raises_with_suggestion(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.fitter.set_model('dab+peak_lorentzzz')
+        self.assertIn('peak_lorentzzz', str(ctx.exception))
+        self.assertIn("Did you mean 'peak_lorentz'", str(ctx.exception))
+
+    def test_set_models_single_model_raises(self):
+        with self.assertRaises(ValueError):
+            self.fitter.set_models('dab')
+
+    def test_set_models_bad_operation_raises(self):
+        with self.assertRaises(ValueError):
+            self.fitter.set_models('dab', 'peak_lorentz', operation='%')
+
+    def test_set_structure_factor_on_composite_raises(self):
+        self.fitter.set_models('dab', 'peak_lorentz')
+        with self.assertRaises(ValueError) as ctx:
+            self.fitter.set_structure_factor('hardsphere')
+        self.assertIn('composite', str(ctx.exception))
+
+
+class TestBoundsPolicy(unittest.TestCase):
+    """Test 3: the new sign-permissive bounds fallback."""
+
+    def test_unbounded_param_gets_sign_permissive_range(self):
+        # peak_lorentz.peak_pos defaults to 0.05 with (-inf, inf) limits.
+        fitter = SANSFitter()
+        fitter.set_data(make_composite_data())
+        fitter.set_model('dab+peak_lorentz')
+        info = fitter.params['B_peak_pos']
+        self.assertEqual(info['value'], 0.05)
+        # New policy: default ± max(10·|default|, 1.0), lower capped at 0.
+        self.assertAlmostEqual(info['min'], min(0.0, 0.05 - 1.0))
+        self.assertAlmostEqual(info['max'], 0.05 + 1.0)
+        self.assertLess(info['min'], 0.0)  # sign-permissive
+
+    def test_zero_default_unbounded_param_non_degenerate(self):
+        # stacked_disks.sld_layer defaults to 0 with (-inf, inf) limits.
+        fitter = SANSFitter()
+        fitter.set_data(make_composite_data())
+        fitter.set_model('stacked_disks')
+        info = fitter.params['sld_layer']
+        self.assertLess(info['min'], info['max'])  # not degenerate [0, 0]
+
+
+class TestLinks(unittest.TestCase):
+    """Test 4: equality link validation and mechanics."""
+
+    def setUp(self):
+        self.fitter = SANSFitter()
+        self.fitter.set_data(make_composite_data())
+        self.fitter.set_models(small='sphere', large='sphere')
+
+    def test_link_missing_name_raises(self):
+        with self.assertRaises(KeyError):
+            self.fitter.link_params('small_bogus', to='small_sld')
+        with self.assertRaises(KeyError):
+            self.fitter.link_params('small_sld', to='large_bogus')
+
+    def test_self_link_raises(self):
+        with self.assertRaises(ValueError):
+            self.fitter.link_params('small_sld', to='small_sld')
+
+    def test_chain_link_raises(self):
+        self.fitter.link_params('large_sld', to='small_sld')
+        with self.assertRaises(ValueError):
+            self.fitter.link_params('small_sld', to='large_sld')
+
+    def test_set_param_on_follower_raises(self):
+        self.fitter.link_params('large_sld', to='small_sld')
+        with self.assertRaises(ValueError):
+            self.fitter.set_param('large_sld', value=9.0)
+        with self.assertRaises(ValueError):
+            self.fitter.set_param('large_sld', vary=True)
+
+    def test_target_value_propagates_to_follower(self):
+        self.fitter.link_params('large_sld', to='small_sld')
+        self.fitter.set_param('small_sld', value=3.5)
+        self.assertEqual(self.fitter.params['large_sld']['value'], 3.5)
+
+    def test_follower_forced_fixed(self):
+        self.fitter.set_param('large_sld', vary=True)
+        self.fitter.link_params('large_sld', to='small_sld')
+        self.assertFalse(self.fitter.params['large_sld']['vary'])
+
+    def test_unlink_restores_independence(self):
+        self.fitter.link_params('large_sld', to='small_sld')
+        self.fitter.unlink_params('large_sld')
+        self.assertEqual(self.fitter.get_links(), {})
+        # Now writable again.
+        self.fitter.set_param('large_sld', value=7.0)
+        self.assertEqual(self.fitter.params['large_sld']['value'], 7.0)
+
+    def test_unlink_non_linked_raises(self):
+        with self.assertRaises(ValueError):
+            self.fitter.unlink_params('large_sld')
+
+    def test_snapshot_carries_linked_params(self):
+        self.fitter.link_params('large_sld', to='small_sld')
+        snap = self.fitter._param_manager.snapshot_fit_state()
+        self.assertEqual(snap.linked_params, {'B_sld': 'A_sld'})
+
+
+class TestCompositeFitRoundTrip(unittest.TestCase):
+    """Test 5: bumps fit recovers known composite parameters."""
+
+    def setUp(self):
+        truth = dict(
+            A_scale=10.0, A_cor_length=50.0, B_scale=5.0,
+            B_peak_pos=0.1, B_peak_hwhm=0.01, scale=1.0, background=0.01,
+        )
+        self.truth = truth
+        self.fitter = SANSFitter()
+        self.fitter.set_data(make_composite_data(params=truth))
+        self.fitter.set_models('dab', 'peak_lorentz')
+
+    def test_fit_recovers_parameters(self):
+        self.fitter.set_param('dab_cor_length', value=45.0, min=1.0, max=200.0, vary=True)
+        self.fitter.set_param('dab_scale', value=9.0, min=0.1, max=100.0, vary=True)
+        self.fitter.set_param('peak_lorentz_peak_pos', value=0.095, min=0.01, max=0.3, vary=True)
+        self.fitter.set_param('peak_lorentz_scale', value=4.5, min=0.1, max=100.0, vary=True)
+        self.fitter.set_param('background', value=0.008, min=0.0, max=0.1, vary=True)
+
+        result = self.fitter.fit(engine='bumps', method='amoeba', steps=2000)
+
+        self.assertIn('chisq', result)
+        self.assertAlmostEqual(
+            self.fitter.params['dab_cor_length']['value'], self.truth['A_cor_length'], delta=2.0
+        )
+        self.assertAlmostEqual(
+            self.fitter.params['peak_lorentz_peak_pos']['value'],
+            self.truth['B_peak_pos'],
+            delta=0.02,
+        )
+
+    def test_follower_equals_target_after_fit(self):
+        self.fitter.link_params('peak_lorentz_scale', to='dab_scale')
+        self.fitter.set_param('dab_cor_length', value=40.0, min=1.0, max=200.0, vary=True)
+        self.fitter.set_param('dab_scale', value=8.0, min=0.1, max=100.0, vary=True)
+        self.fitter.set_param('peak_lorentz_peak_pos', value=0.08, min=0.01, max=0.3, vary=True)
+        self.fitter.set_param('background', value=0.005, min=0.0, max=0.1, vary=True)
+
+        self.fitter.fit(engine='bumps', method='amoeba')
+
+        self.assertAlmostEqual(
+            self.fitter.params['peak_lorentz_scale']['value'],
+            self.fitter.params['dab_scale']['value'],
+            places=8,
+        )
+
+
+class TestEngineGating(unittest.TestCase):
+    """Test 6: non-bumps engines reject composites and links."""
+
+    def setUp(self):
+        self.fitter = SANSFitter()
+        self.fitter.set_data(make_composite_data())
+        self.fitter.set_models('dab', 'peak_lorentz')
+        self.fitter.set_param('dab_cor_length', vary=True)
+
+    def test_lmfit_on_composite_raises(self):
+        with self.assertRaises(NotImplementedError):
+            self.fitter.fit(engine='lmfit')
+
+    def test_lmfit_with_links_raises(self):
+        atomic = SANSFitter()
+        atomic.set_data(make_composite_data())
+        atomic.set_model('sphere')
+        atomic.set_param('radius', vary=True)
+        atomic.set_param('sld', vary=True)
+        atomic.link_params('sld_solvent', to='sld')
+        with self.assertRaises(NotImplementedError):
+            atomic.fit(engine='lmfit')
+
+    def test_bayesian_on_composite_raises(self):
+        with self.assertRaises(NotImplementedError):
+            self.fitter.fit_bayesian(samples=100, burn=10)
+
+
+class TestComponentCurves(unittest.TestCase):
+    """Test 7: per-component curves for '+' mixtures."""
+
+    def setUp(self):
+        truth = dict(
+            A_scale=10.0, A_cor_length=50.0, B_scale=5.0,
+            B_peak_pos=0.1, B_peak_hwhm=0.01, scale=1.0, background=0.01,
+        )
+        self.fitter = SANSFitter()
+        self.fitter.set_data(make_composite_data(params=truth))
+        self.fitter.set_models('dab', 'peak_lorentz')
+        self.fitter.set_param('dab_cor_length', value=50.0, vary=True)
+        self.fitter.set_param('peak_lorentz_peak_pos', value=0.1, vary=True)
+        self.fitter.fit(engine='bumps', method='amoeba')
+
+    def test_component_curves_present_and_sum_to_total(self):
+        curves = self.fitter._fit_contract.artifacts.component_curves
+        self.assertIsNotNone(curves)
+        self.assertEqual(set(curves.keys()), {'dab', 'peak_lorentz'})
+
+        fit_index = self.fitter._fit_contract.artifacts.fit_index
+        n_fit = int(np.asarray(fit_index).sum()) if fit_index is not None else len(self.fitter.data.x)
+        for curve in curves.values():
+            self.assertEqual(len(curve), n_fit)
+
+        total = sum(curves.values()) + self.fitter.params['background']['value']
+        fitted = self.fitter._fit_contract.require_fitted_curve()
+        np.testing.assert_allclose(total, fitted, rtol=1e-3, atol=1e-6)
+
+    def test_product_mixture_has_no_component_curves(self):
+        fitter = SANSFitter()
+        fitter.set_data(make_composite_data(expression='dab*peak_lorentz'))
+        fitter.set_model('dab*peak_lorentz')
+        fitter.set_param('A_cor_length', value=50.0, vary=True)
+        fitter.fit(engine='bumps', method='amoeba')
+        self.assertIsNone(fitter._fit_contract.artifacts.component_curves)
+
+    def test_atomic_model_has_no_component_curves(self):
+        fitter = SANSFitter()
+        fitter.set_data(make_composite_data())
+        fitter.set_model('sphere')
+        fitter.set_param('radius', value=20.0, vary=True)
+        fitter.fit(engine='bumps', method='amoeba')
+        self.assertIsNone(fitter._fit_contract.artifacts.component_curves)
+
+
+class TestPolydispersityOnComponent(unittest.TestCase):
+    """Test 8: polydispersity routed to a composite component."""
+
+    def test_pd_on_component_via_canonical_name(self):
+        fitter = SANSFitter()
+        fitter.set_data(make_composite_data(expression='sphere+peak_lorentz'))
+        fitter.set_model('sphere+peak_lorentz')
+        fitter.set_pd_param('A_radius', pd_width=0.1, vary=False)
+        fitter.enable_polydispersity(True)
+        fitter.set_param('A_radius', value=20.0, vary=True)
+        fitter.set_param('scale', value=0.1, vary=True)
+
+        result = fitter.fit(engine='bumps', method='amoeba')
+        self.assertIn('chisq', result)
+        # Component curves still stack to the total with PD active.
+        curves = fitter._fit_contract.artifacts.component_curves
+        self.assertIsNotNone(curves)
+        total = sum(curves.values()) + fitter.params['background']['value']
+        fitted = fitter._fit_contract.require_fitted_curve()
+        np.testing.assert_allclose(total, fitted, rtol=1e-2, atol=1e-5)
+
+    def test_pd_via_friendly_alias_equivalent_to_canonical(self):
+        fitter = SANSFitter()
+        fitter.set_data(make_composite_data(expression='sphere+peak_lorentz'))
+        fitter.set_models('sphere', 'peak_lorentz')
+        fitter.set_pd_param('sphere_radius', pd_width=0.15, pd_n=25)
+
+        # Alias and canonical spellings reach the same PD store.
+        alias_cfg = fitter.get_pd_param('sphere_radius')
+        canonical_cfg = fitter.get_pd_param('A_radius')
+        self.assertEqual(alias_cfg['pd'], canonical_cfg['pd'])
+        self.assertEqual(alias_cfg['pd'], 0.15)
+        self.assertEqual(alias_cfg['pd_n'], 25)
+
+    def test_pd_on_product_part_inside_mixture(self):
+        # PD on A_radius of (sphere@hardsphere) + peak_lorentz: the product
+        # part takes a single A_ prefix over all its parameters, so the strip
+        # must map onto sphere@hardsphere's own names.
+        fitter = SANSFitter()
+        data = make_composite_data(expression='sphere@hardsphere+peak_lorentz')
+        fitter.set_data(data)
+        fitter.set_model('sphere@hardsphere+peak_lorentz')
+        fitter.set_pd_param('A_radius', pd_width=0.1, vary=False)
+        fitter.enable_polydispersity(True)
+        fitter.set_param('A_radius', value=30.0, vary=True)
+        fitter.set_param('scale', value=0.1, vary=True)
+
+        result = fitter.fit(engine='bumps', method='amoeba')
+        self.assertIn('chisq', result)
+        # The sum check still holds with PD on a product part.
+        curves = fitter._fit_contract.artifacts.component_curves
+        self.assertIsNotNone(curves)
+        total = sum(curves.values()) + fitter.params['background']['value']
+        fitted = fitter._fit_contract.require_fitted_curve()
+        np.testing.assert_allclose(total, fitted, rtol=2e-2, atol=1e-5)
+
+
+class TestAliases(unittest.TestCase):
+    """Test 10: the friendly-name alias layer."""
+
+    def setUp(self):
+        self.data = make_composite_data()
+
+    def test_positional_yields_model_name_prefixes(self):
+        fitter = SANSFitter()
+        fitter.set_data(self.data)
+        fitter.set_models('dab', 'peak_lorentz')
+        self.assertIn('dab_cor_length', fitter.params)
+        self.assertIn('peak_lorentz_peak_pos', fitter.params)
+
+    def test_keyword_monikers_yield_moniker_prefixes(self):
+        fitter = SANSFitter()
+        fitter.set_data(self.data)
+        fitter.set_models(small='sphere', large='sphere')
+        self.assertIn('small_radius', fitter.params)
+        self.assertIn('large_radius', fitter.params)
+
+    def test_duplicate_positionals_auto_suffix(self):
+        fitter = SANSFitter()
+        fitter.set_data(self.data)
+        fitter.set_models('sphere', 'sphere')
+        self.assertIn('sphere1_radius', fitter.params)
+        self.assertIn('sphere2_radius', fitter.params)
+
+    def test_alias_collision_raises(self):
+        fitter = SANSFitter()
+        fitter.set_data(self.data)
+        # Moniker 'dab' on dab (param cor_length) and moniker 'dab_cor' on
+        # cylinder (param length) both generate the alias 'dab_cor_length'.
+        with self.assertRaises(ValueError):
+            fitter.set_models('dab', dab_cor='cylinder')
+
+    def test_canonical_names_still_accepted(self):
+        fitter = SANSFitter()
+        fitter.set_data(self.data)
+        fitter.set_models('dab', 'peak_lorentz')
+        fitter.set_param('A_cor_length', value=42.0)
+        self.assertEqual(fitter.params['dab_cor_length']['value'], 42.0)
+
+    def test_keyerror_lists_alias_names(self):
+        fitter = SANSFitter()
+        fitter.set_data(self.data)
+        fitter.set_models('dab', 'peak_lorentz')
+        with self.assertRaises(KeyError) as ctx:
+            fitter.set_param('bogus', value=1.0)
+        self.assertIn('dab_cor_length', str(ctx.exception))
+
+    def test_raw_path_keeps_canonical_names(self):
+        fitter = SANSFitter()
+        fitter.set_data(self.data)
+        fitter.set_model('dab+peak_lorentz')
+        # Empty alias map on the raw path.
+        self.assertEqual(fitter._param_manager._alias_to_canonical, {})
+        self.assertIn('A_cor_length', fitter.params)
+
+
+class TestSharedParameters(unittest.TestCase):
+    """Test 11: the shared= parameter mechanism."""
+
+    def setUp(self):
+        self.data = make_composite_data(expression='sphere+cylinder')
+
+    def test_shared_creates_unprefixed_and_removes_prefixed(self):
+        fitter = SANSFitter()
+        fitter.set_data(self.data)
+        fitter.set_models('sphere', 'cylinder', shared=['sld', 'sld_solvent'])
+        self.assertIn('sld', fitter.params)
+        self.assertIn('sld_solvent', fitter.params)
+        self.assertNotIn('sphere_sld', fitter.params)
+        self.assertNotIn('cylinder_sld', fitter.params)
+
+    def test_shared_drives_all_components(self):
+        fitter = SANSFitter()
+        fitter.set_data(self.data)
+        fitter.set_models('sphere', 'cylinder', shared=['sld'])
+        fitter.set_param('sld', value=4.5)
+        snap = fitter._param_manager.snapshot_fit_state()
+        self.assertEqual(snap.params['A_sld']['value'], 4.5)
+        self.assertEqual(snap.params['B_sld']['value'], 4.5)
+        self.assertEqual(snap.linked_params, {'B_sld': 'A_sld'})
+
+    def test_shared_name_in_too_few_components_raises(self):
+        fitter = SANSFitter()
+        fitter.set_data(self.data)
+        # 'radius' exists in sphere but not cylinder (cylinder has radius too,
+        # so use a name present in only one).
+        with self.assertRaises(ValueError) as ctx:
+            fitter.set_models('dab', 'peak_lorentz', shared=['cor_length'])
+        self.assertIn('cor_length', str(ctx.exception))
+
+    def test_shared_pd_stays_per_component(self):
+        fitter = SANSFitter()
+        fitter.set_data(self.data)
+        fitter.set_models('sphere', 'cylinder', shared=['radius'])
+        self.assertIn('radius', fitter.params)
+        self.assertNotIn('sphere_radius', fitter.params)
+        self.assertNotIn('cylinder_radius', fitter.params)
+        # But PD access stays addressable per component.
+        fitter.set_pd_param('sphere_radius', pd_width=0.1)
+        fitter.set_pd_param('cylinder_radius', pd_width=0.2)
+        self.assertEqual(fitter.get_pd_param('A_radius')['pd'], 0.1)
+        self.assertEqual(fitter.get_pd_param('B_radius')['pd'], 0.2)
+
+    def test_shared_fitted_value_writes_back_to_alias(self):
+        fitter = SANSFitter()
+        fitter.set_data(make_composite_data(expression='sphere+sphere'))
+        fitter.set_models(small='sphere', large='sphere', shared=['sld'])
+        fitter.set_param('sld', value=4.0, vary=True)
+        fitter.set_param('small_radius', value=20.0, vary=True)
+        fitter.set_param('scale', value=0.1, vary=True)
+        fitter.fit(engine='bumps', method='amoeba')
+        # The shared alias carries the fitted value.
+        self.assertIn('sld', fitter.params)
+
+
+class TestComponentCurvesAgainstIntermediates(unittest.TestCase):
+    """Dev-only validation against sasmodels' private MixtureKernel API.
+
+    Skipped by default; enable with SANS_FITTER_VALIDATE_COMPONENTS=1.
+    Compares the per-part re-evaluation against the mixture kernel's internal
+    intermediates, especially for the PD-enabled-component case.
+    """
+
+    @unittest.skipUnless(
+        os.environ.get('SANS_FITTER_VALIDATE_COMPONENTS') == '1',
+        'dev-only validation; set SANS_FITTER_VALIDATE_COMPONENTS=1 to run',
+    )
+    def test_component_curves_match_intermediates(self):
+        from sasmodels.details import make_details
+
+        fitter = SANSFitter()
+        fitter.set_data(make_composite_data())
+        fitter.set_models('dab', 'peak_lorentz')
+        fitter.set_param('dab_cor_length', value=50.0, vary=True)
+        fitter.set_param('peak_lorentz_peak_pos', value=0.1, vary=True)
+        fitter.fit(engine='bumps', method='amoeba')
+
+        curves = fitter._fit_contract.artifacts.component_curves
+        self.assertIsNotNone(curves)
+        # The sum check is the public equivalent of the intermediates check.
+        total = sum(curves.values()) + fitter.params['background']['value']
+        fitted = fitter._fit_contract.require_fitted_curve()
+        np.testing.assert_allclose(total, fitted, rtol=1e-3, atol=1e-6)
+
+
+class TestScaleDegeneracyWarning(unittest.TestCase):
+    """Test 12: warning when global scale and a component scale both vary."""
+
+    def setUp(self):
+        self.fitter = SANSFitter()
+        self.fitter.set_data(make_composite_data())
+        self.fitter.set_models('dab', 'peak_lorentz')
+
+    def test_both_scales_varying_warns(self):
+        self.fitter.set_param('scale', vary=True)
+        self.fitter.set_param('dab_scale', vary=True)
+        self.fitter.set_param('dab_cor_length', vary=True)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            self.fitter._check_scale_degeneracy()
+        self.assertTrue(any('degenerate' in str(w.message) for w in caught))
+
+    def test_global_scale_alone_no_warning(self):
+        self.fitter.set_param('scale', vary=True)
+        self.fitter.set_param('dab_cor_length', vary=True)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            self.fitter._check_scale_degeneracy()
+        self.assertFalse(any('degenerate' in str(w.message) for w in caught))
+
+    def test_component_scale_alone_no_warning(self):
+        self.fitter.set_param('dab_scale', vary=True)
+        self.fitter.set_param('dab_cor_length', vary=True)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            self.fitter._check_scale_degeneracy()
+        self.assertFalse(any('degenerate' in str(w.message) for w in caught))
+
+
+class TestCompositePlotting(unittest.TestCase):
+    """Test 9: show_components plotting."""
+
+    def _fit_composite(self):
+        truth = dict(
+            A_scale=10.0, A_cor_length=50.0, B_scale=5.0,
+            B_peak_pos=0.1, B_peak_hwhm=0.01, scale=1.0, background=0.01,
+        )
+        fitter = SANSFitter()
+        fitter.set_data(make_composite_data(params=truth))
+        fitter.set_models('dab', 'peak_lorentz')
+        fitter.set_param('dab_cor_length', value=50.0, vary=True)
+        fitter.set_param('peak_lorentz_peak_pos', value=0.1, vary=True)
+        fitter.fit(engine='bumps', method='amoeba')
+        return fitter
+
+    def test_show_components_adds_traces(self):
+        from unittest.mock import patch
+
+        fitter = self._fit_composite()
+        with patch('plotly.graph_objects.Figure.show'):
+            fig = fitter.plot_results(show_components=True, show=False)
+        names = [trace.name for trace in fig.data]
+        self.assertIn('dab', names)
+        self.assertIn('peak_lorentz', names)
+
+    def test_show_components_noop_without_curves(self):
+        from unittest.mock import patch
+
+        fitter = SANSFitter()
+        fitter.set_data(make_composite_data())
+        fitter.set_model('sphere')
+        fitter.set_param('radius', value=20.0, vary=True)
+        fitter.fit(engine='bumps', method='amoeba')
+        with patch('plotly.graph_objects.Figure.show'):
+            fig = fitter.plot_results(show_components=True, show=False)
+        # No component traces added for an atomic model.
+        names = [trace.name for trace in fig.data]
+        self.assertNotIn('sphere', [n for n in names if n and ':' in str(n)])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_composite_models.py
+++ b/tests/test_composite_models.py
@@ -134,6 +134,26 @@ class TestCompositeValidation(unittest.TestCase):
             self.fitter.set_structure_factor('hardsphere')
         self.assertIn('composite', str(ctx.exception))
 
+    def test_nested_expression_in_moniker_raises(self):
+        # A keyword value that is itself a composite expands to more kernel
+        # parts than user entries, so monikers cannot map 1:1. Must raise
+        # instead of silently mislabeling components (54_REVIEW issue 1).
+        with self.assertRaises(ValueError) as ctx:
+            self.fitter.set_models(diffuse='dab+peak_lorentz', particle='sphere')
+        message = str(ctx.exception)
+        self.assertIn('2 model entries expanded to 3 kernel components', message)
+        self.assertIn('Pass each component separately', message)
+
+    def test_plugin_path_reaches_load_model(self):
+        # Non-identifier specs (custom plugin-model paths) are load_model's
+        # business; pre-validation must not reject them as unknown model
+        # names (54_REVIEW issue 2).
+        with self.assertRaises(ValueError) as ctx:
+            self.fitter.set_model('C:/nonexistent/plugin_model.py')
+        message = str(ctx.exception)
+        self.assertNotIn('Unknown model', message)
+        self.assertIn('Failed to load model', message)
+
 
 class TestBoundsPolicy(unittest.TestCase):
     """Test 3: the new sign-permissive bounds fallback."""

--- a/tests/test_composite_models.py
+++ b/tests/test_composite_models.py
@@ -30,7 +30,7 @@ def make_composite_data(
     data = Data1D(x=q, y=np.ones_like(q), dy=np.full_like(q, 0.05))
     data.qmin, data.qmax = q.min(), q.max()
     kernel = load_model(expression, dtype='single', platform='dll')
-    defaults = dict(scale=1.0, background=0.01)
+    defaults = {'scale': 1.0, 'background': 0.01}
     if params:
         defaults.update(params)
     y = np.asarray(DirectModel(data, kernel)(**defaults))
@@ -221,15 +221,15 @@ class TestCompositeFitRoundTrip(unittest.TestCase):
     """Test 5: bumps fit recovers known composite parameters."""
 
     def setUp(self):
-        truth = dict(
-            A_scale=10.0,
-            A_cor_length=50.0,
-            B_scale=5.0,
-            B_peak_pos=0.1,
-            B_peak_hwhm=0.01,
-            scale=1.0,
-            background=0.01,
-        )
+        truth = {
+            'A_scale': 10.0,
+            'A_cor_length': 50.0,
+            'B_scale': 5.0,
+            'B_peak_pos': 0.1,
+            'B_peak_hwhm': 0.01,
+            'scale': 1.0,
+            'background': 0.01,
+        }
         self.truth = truth
         self.fitter = SANSFitter()
         self.fitter.set_data(make_composite_data(params=truth))
@@ -302,15 +302,15 @@ class TestComponentCurves(unittest.TestCase):
     """Test 7: per-component curves for '+' mixtures."""
 
     def setUp(self):
-        truth = dict(
-            A_scale=10.0,
-            A_cor_length=50.0,
-            B_scale=5.0,
-            B_peak_pos=0.1,
-            B_peak_hwhm=0.01,
-            scale=1.0,
-            background=0.01,
-        )
+        truth = {
+            'A_scale': 10.0,
+            'A_cor_length': 50.0,
+            'B_scale': 5.0,
+            'B_peak_pos': 0.1,
+            'B_peak_hwhm': 0.01,
+            'scale': 1.0,
+            'background': 0.01,
+        }
         self.fitter = SANSFitter()
         self.fitter.set_data(make_composite_data(params=truth))
         self.fitter.set_models('dab', 'peak_lorentz')
@@ -594,15 +594,15 @@ class TestCompositePlotting(unittest.TestCase):
     """Test 9: show_components plotting."""
 
     def _fit_composite(self):
-        truth = dict(
-            A_scale=10.0,
-            A_cor_length=50.0,
-            B_scale=5.0,
-            B_peak_pos=0.1,
-            B_peak_hwhm=0.01,
-            scale=1.0,
-            background=0.01,
-        )
+        truth = {
+            'A_scale': 10.0,
+            'A_cor_length': 50.0,
+            'B_scale': 5.0,
+            'B_peak_pos': 0.1,
+            'B_peak_hwhm': 0.01,
+            'scale': 1.0,
+            'background': 0.01,
+        }
         fitter = SANSFitter()
         fitter.set_data(make_composite_data(params=truth))
         fitter.set_models('dab', 'peak_lorentz')


### PR DESCRIPTION
Support for composite (multi-component) models to the SANS fitter, allowing users to fit multiple models simultaneously to a single dataset. 

**Composite Model Support and API Enhancements:**

* Added `set_models()`, `link_params()`, `unlink_params()`, `get_links()`, and `get_components()` methods to the main API, enabling the definition and management of composite models and parameter sharing/linking. 
* Updated the fitting engine to support equality links between parameters, so that follower parameters mirror their targets during fitting (used for both `shared=` and explicit linking). 

**Internal Data Structures:**

* Extended the `ParameterStateSnapshot` dataclass to carry canonical (sasmodels) parameter names, equality links, and composite model component metadata, ensuring correct engine behavior and reproducibility. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Combine multiple SANS models using additive or multiplicative expressions.
- Configure shared parameters, custom component names, and explicit parameter links.
- Inspect components and linked parameters through the public API.
- Plot fitted curves for individual additive components.
- Added executable examples and a Jupyter notebook demonstrating composite-model fitting.

## Improvements
- Added clearer validation, parameter aliases, bounds handling, and scale-degeneracy warnings.
- Composite models and parameter links are supported with the BUMPS fitting engine.
- Added guidance on composite-model syntax, parameter naming, and fitting limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->