### PR TITLE
31 - query sasmodels for available structure factors. Initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ result = fitter.fit()
 fitter.remove_structure_factor()
 ```
 
-- **Supported structure factors:** `hardsphere`, `hayter_msa`, `squarewell`, `stickyhardsphere`.
+- **Structure factors:** queried from sasmodels at runtime — call `get_structure_factors()` for the full list (currently includes `hardsphere`, `hayter_msa`, `squarewell`, `stickyhardsphere`, `two_yukawa`).
 - **Radius handling:** use `radius_effective_mode='link_radius'` to keep `radius_effective` equal to the form-factor `radius`, or leave the default `unconstrained` to fit it independently.
 - **State helpers:** `get_structure_factor()` returns the active structure factor so notebooks/scripts can branch as needed.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,10 @@
 # API Reference
 
+## Module-level helpers
+
+::: sans_fitter.fitter.get_all_models
+::: sans_fitter.fitter.get_structure_factors
+
 ## SANSFitter
 
 The main class for SANS data fitting.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -276,11 +276,19 @@ fitter.set_model('sphere')
 fitter.set_structure_factor('hardsphere')
 ```
 
-Supported structure factors include:
--   `hardsphere`
--   `hayter_msa`
--   `squarewell`
--   `stickyhardsphere`
+The available structure factors are **queried from sasmodels at runtime** (not
+hardcoded), so new ones added upstream are picked up automatically. List them
+with `get_structure_factors()`:
+
+```python
+from sans_fitter import get_structure_factors
+
+get_structure_factors()
+# e.g. ('hardsphere', 'hayter_msa', 'squarewell', 'stickyhardsphere', 'two_yukawa')
+```
+
+As of the current sasmodels install this includes `hardsphere`, `hayter_msa`,
+`squarewell`, `stickyhardsphere`, and `two_yukawa`.
 
 ### Effective Radius
 

--- a/src/sans_fitter/__init__.py
+++ b/src/sans_fitter/__init__.py
@@ -5,7 +5,7 @@ SANS Model Fitter - A flexible template for fitting SANS data with SasModels
 from . import examples
 from . import inversion as pr_inversion
 from .data import ops as data_ops
-from .fitter import SANSFitter, get_all_models
+from .fitter import SANSFitter, get_all_models, get_structure_factors
 from .inversion import InsufficientDataError, PrEstimationError, PrResult
 from .modeling.parameters import ParameterManager
 from .modeling.polydispersity import PD_DEFAULTS, PD_DISTRIBUTION_TYPES
@@ -18,6 +18,7 @@ __all__ = [
     'PD_DEFAULTS',
     'PD_DISTRIBUTION_TYPES',
     'get_all_models',
+    'get_structure_factors',
     'FitResultContract',
     'data_ops',
     'examples',

--- a/src/sans_fitter/fitter.py
+++ b/src/sans_fitter/fitter.py
@@ -6,6 +6,7 @@ optimization engines (BUMPS, LMFit) with any model from the SasModels library.
 """
 
 import difflib
+import functools
 import re
 import warnings
 from collections.abc import Sequence
@@ -50,6 +51,25 @@ def get_all_models() -> list[str]:
     except Exception as e:
         print(f'Error fetching models: {str(e)}')
         return []
+
+
+@functools.lru_cache(maxsize=1)
+def get_structure_factors() -> tuple[str, ...]:
+    """Return the structure-factor model names available in sasmodels.
+
+    Derived from sasmodels rather than a hardcoded whitelist: every built-in
+    model whose ``ModelInfo.structure_factor`` flag is set (via
+    ``sasmodels.core.load_model_info``). New structure factors added upstream
+    (e.g. ``two_yukawa``) are picked up automatically, so this list cannot go
+    stale. The result is cached; the immutable tuple prevents accidental
+    mutation of the cached value.
+
+    Returns:
+        Sorted tuple of structure-factor names.
+    """
+    return tuple(
+        sorted(name for name in core.list_models() if core.load_model_info(name).structure_factor)
+    )
 
 
 def _validate_model_expression(model_name: str) -> None:
@@ -567,11 +587,9 @@ class SANSFitter:
         This creates a product model (form_factor * structure_factor) to account
         for inter-particle interactions in concentrated systems.
 
-        Supported structure factors:
-        - 'hardsphere': Hard sphere structure factor (Percus-Yevick closure)
-        - 'hayter_msa': Hayter-Penfold rescaled MSA for charged spheres
-        - 'squarewell': Square well potential
-        - 'stickyhardsphere': Sticky hard sphere (Baxter model)
+        Available structure factors are queried from sasmodels at runtime —
+        see :func:`get_structure_factors` for the full, up-to-date list
+        (e.g. 'hardsphere', 'hayter_msa', 'squarewell', 'stickyhardsphere').
 
         Args:
             structure_factor_name: Name of the structure factor (e.g., 'hardsphere')
@@ -594,8 +612,8 @@ class SANSFitter:
                 "part instead, e.g. set_models('sphere@hardsphere', 'peak_lorentz')."
             )
 
-        # Validate structure factor name
-        supported_sf = ['hardsphere', 'hayter_msa', 'squarewell', 'stickyhardsphere']
+        # Validate structure factor name against sasmodels (cached query)
+        supported_sf = get_structure_factors()
         if structure_factor_name not in supported_sf:
             raise ValueError(
                 f"Unsupported structure factor '{structure_factor_name}'. "

--- a/tests/test_structure_factor.py
+++ b/tests/test_structure_factor.py
@@ -1,8 +1,46 @@
 import os
 import unittest
 
-from sans_fitter import SANSFitter
+from sasmodels import core
+
+from sans_fitter import SANSFitter, get_structure_factors
 from tests.helpers import create_concentrated_sphere_data_file
+
+
+class TestStructureFactorDiscovery(unittest.TestCase):
+    """Structure factors are derived from sasmodels, not a hardcoded whitelist."""
+
+    def test_includes_previously_hardcoded_names(self):
+        names = get_structure_factors()
+        for expected in ('hardsphere', 'hayter_msa', 'squarewell', 'stickyhardsphere'):
+            self.assertIn(expected, names)
+
+    def test_every_name_is_a_real_structure_factor(self):
+        names = get_structure_factors()
+        self.assertTrue(names)  # non-empty
+        self.assertEqual(sorted(names), list(names))  # sorted
+        for name in names:
+            self.assertTrue(core.load_model_info(name).structure_factor, name)
+
+    def test_is_subset_of_sasmodels_models(self):
+        self.assertTrue(set(get_structure_factors()) <= set(core.list_models()))
+
+    def test_matches_sasmodels_source_of_truth(self):
+        # Guards against regressing to a stale hardcoded list: the function
+        # must equal exactly what sasmodels reports today.
+        expected = {
+            name for name in core.list_models() if core.load_model_info(name).structure_factor
+        }
+        self.assertEqual(set(get_structure_factors()), expected)
+
+    def test_newly_supported_structure_factor_is_usable(self):
+        if 'two_yukawa' not in get_structure_factors():
+            self.skipTest('two_yukawa not available in this sasmodels')
+        fitter = SANSFitter()
+        fitter.set_model('sphere')
+        fitter.set_structure_factor('two_yukawa')
+        self.assertEqual(fitter.get_structure_factor(), 'two_yukawa')
+        self.assertIn('volfraction', fitter.params)
 
 
 class TestStructureFactorSetup(unittest.TestCase):


### PR DESCRIPTION
**Dynamic structure factor discovery and validation:**

* Added a new `get_structure_factors()` helper function that queries available structure factors from `sasmodels` at runtime, replacing hardcoded lists throughout the codebase. The result is cached for efficiency.
* Updated the `set_structure_factor` method in `SANSFitter` to validate structure factor names against the dynamic list returned by `get_structure_factors()`, rather than a static whitelist.
