### PR TITLE
50 multi dataset files

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -22,6 +22,24 @@ fitter = SANSFitter()
 fitter.load_data('path/to/data.csv')
 ```
 
+Some files contain **more than one dataset** (e.g. a CanSAS XML with several
+`SASentry` blocks, or an NXcanSAS file with multiple entries). In that case
+`load_data()` (and `data_ops.load()`) print a warning listing all available
+datasets and load the first one. Select a specific dataset by 0-based index
+or by name (title, run id, or filename):
+
+```python
+# Pick the second dataset by index
+fitter.load_data('multi_dataset.xml', dataset=1)
+
+# Or by name (title, run id, or filename)
+fitter.load_data('multi_dataset.xml', dataset='beta sample')
+
+# data_ops.load accepts the same argument
+import sans_fitter.data_ops as data_ops
+sample = data_ops.load('multi_dataset.xml', dataset='beta sample')
+```
+
 ### 2. Selecting a Model
 
 You can use any model available in the [SasModels library](https://www.sasview.org/docs/user/models/index.html).

--- a/src/sans_fitter/data/loader.py
+++ b/src/sans_fitter/data/loader.py
@@ -148,8 +148,7 @@ def _select_dataset(data_list: list[Any], filename: str, dataset: int | str) -> 
         if not matches:
             available = ', '.join(f'{i}: {_dataset_label(d, i)}' for i, d in enumerate(data_list))
             raise ValueError(
-                f'No dataset named {dataset!r} in {filename}. '
-                f'Available datasets: {available}.'
+                f'No dataset named {dataset!r} in {filename}. Available datasets: {available}.'
             )
         if len(matches) > 1:
             raise ValueError(

--- a/src/sans_fitter/data/loader.py
+++ b/src/sans_fitter/data/loader.py
@@ -1,3 +1,5 @@
+import os
+import warnings
 from typing import Any
 
 import numpy as np
@@ -61,15 +63,99 @@ def normalize_sans_data(data: Any) -> Any:
     return data
 
 
-def load_sans_data(filename: str) -> Any:
-    """Load SANS data and normalize required fields for downstream fitting."""
-    loader = Loader()
+def load_sans_data(filename: str, dataset: int | str = 0) -> Any:
+    """Load a single SANS dataset from *filename* and make it fit-ready.
 
+    SANS files may hold several datasets (e.g. a CanSAS XML with multiple
+    ``SASentry`` blocks, or an NXcanSAS file with several entries). By default
+    the first dataset is returned; pass *dataset* to choose another one by
+    0-based index or by name (title, run id or filename). When the file
+    contains more than one dataset, a warning lists them all so the caller
+    knows a different selection was possible.
+
+    Args:
+        filename: Path to the data file.
+        dataset: Which dataset to return — a 0-based index or a name (title,
+            run id or filename). Defaults to the first dataset.
+
+    Returns:
+        A fit-ready dataset with ``qmin``/``qmax``/``mask`` set.
+
+    Raises:
+        ValueError: If the file cannot be loaded, contains no data, or the
+            requested dataset does not exist or is ambiguous.
+    """
+    data_list = _load_all(filename)
+    index = _select_dataset(data_list, filename, dataset)
+
+    if len(data_list) > 1:
+        listing = ', '.join(f'{i}: {_dataset_label(d, i)}' for i, d in enumerate(data_list))
+        warnings.warn(
+            f'{os.path.basename(filename)} contains {len(data_list)} datasets '
+            f'({listing}); returning dataset {_dataset_label(data_list[index], index)!r}. '
+            'Pass dataset=<index or name> to load a different one.',
+            stacklevel=3,
+        )
+
+    return normalize_sans_data(data_list[index])
+
+
+def _load_all(filename: str) -> list[Any]:
+    """Return every dataset found in *filename* via sasdata, or raise."""
+    loader = Loader()
     try:
         data_list = loader.load(filename)
         if not data_list:
             raise ValueError(f'No data loaded from {filename}')
-
-        return normalize_sans_data(data_list[0])
+        return data_list
     except Exception as e:
         raise ValueError(f'Failed to load data from {filename}: {str(e)}') from e
+
+
+def _dataset_names(data: Any) -> list[str]:
+    """Names a dataset can be labelled or selected by (title, run id, filename)."""
+    names: list[str] = []
+    for attr in ('title', 'name'):
+        value = getattr(data, attr, None)
+        if value:
+            names.append(str(value))
+    run = getattr(data, 'run', None)
+    names.extend(str(v) for v in (run if isinstance(run, (list, tuple)) else [run]) if v)
+    filename = getattr(data, 'filename', None)
+    if filename:
+        basename = os.path.basename(filename)
+        names += [basename, os.path.splitext(basename)[0]]
+    return [name for name in dict.fromkeys(names) if name]
+
+
+def _dataset_label(data: Any, index: int) -> str:
+    """Short human-readable name for a loaded dataset, for messages."""
+    names = _dataset_names(data)
+    return names[0] if names else f'dataset #{index}'
+
+
+def _select_dataset(data_list: list[Any], filename: str, dataset: int | str) -> int:
+    """Resolve *dataset* (int index or str name) to a position in *data_list*."""
+    if isinstance(dataset, int) and not isinstance(dataset, bool):  # bool subclasses int
+        if not 0 <= dataset < len(data_list):
+            raise ValueError(
+                f'Dataset index {dataset} is out of range for {filename}: '
+                f'file contains {len(data_list)} dataset(s) (0–{len(data_list) - 1}).'
+            )
+        return dataset
+    if isinstance(dataset, str):
+        matches = [i for i, d in enumerate(data_list) if dataset in _dataset_names(d)]
+        if not matches:
+            available = ', '.join(f'{i}: {_dataset_label(d, i)}' for i, d in enumerate(data_list))
+            raise ValueError(
+                f'No dataset named {dataset!r} in {filename}. '
+                f'Available datasets: {available}.'
+            )
+        if len(matches) > 1:
+            raise ValueError(
+                f'Dataset name {dataset!r} is ambiguous in {filename}: matches datasets '
+                f'{matches} ({", ".join(_dataset_label(data_list[i], i) for i in matches)}). '
+                'Select by 0-based index instead.'
+            )
+        return matches[0]
+    raise TypeError(f'dataset must be an int index or a str name, got {type(dataset).__name__}.')

--- a/src/sans_fitter/data/ops.py
+++ b/src/sans_fitter/data/ops.py
@@ -58,7 +58,7 @@ _OPERATORS = {
 }
 
 
-def load(filename: str) -> Data1D:
+def load(filename: str, dataset: int | str = 0) -> Data1D:
     """Load a SANS dataset from a file and return a fit-ready ``Data1D``.
 
     This is the canonical standalone loader: ``SANSFitter.load_data()`` uses
@@ -66,16 +66,25 @@ def load(filename: str) -> Data1D:
     those loaded through the fitter. Supports CSV, XML and HDF5 formats via
     sasdata (columnar text files are read in the order Q, I, dI, dQ).
 
+    Files may hold several datasets (e.g. CanSAS XML with multiple
+    ``SASentry`` blocks). Pass *dataset* to select one by 0-based index or by
+    name (title, run id or filename); the first dataset is used by default. A
+    warning is emitted whenever the file contains more than one dataset,
+    listing them so a different selection is possible.
+
     Args:
         filename: Path to the data file.
+        dataset: Which dataset to load — a 0-based index or a name (title,
+            run id or filename). Defaults to the first dataset.
 
     Returns:
         A ``Data1D`` object with ``qmin``/``qmax``/``mask`` set.
 
     Raises:
-        ValueError: If the file cannot be loaded or contains no data.
+        ValueError: If the file cannot be loaded, contains no data, or the
+            requested dataset does not exist or is ambiguous.
     """
-    return load_sans_data(filename)
+    return load_sans_data(filename, dataset=dataset)
 
 
 def add(a: Data1D, b: Operand) -> Data1D:

--- a/src/sans_fitter/fitter.py
+++ b/src/sans_fitter/fitter.py
@@ -121,7 +121,7 @@ class SANSFitter:
         # Parameter management delegated to ParameterManager
         self._param_manager = ParameterManager()
 
-    def load_data(self, filename: str) -> None:
+    def load_data(self, filename: str, dataset: int | str = 0) -> None:
         """
         Load SANS data from a file.
 
@@ -131,14 +131,22 @@ class SANSFitter:
         its uncertainties and resolution swapped. Check the column summary
         printed after loading.
 
+        Files may hold several datasets (e.g. CanSAS XML with multiple
+        ``SASentry`` blocks). Pass *dataset* to select one by 0-based index or
+        by name (title, run id or filename); the first dataset is used by
+        default. If the file contains more than one dataset, a warning lists
+        them all.
+
         Args:
             filename: Path to the data file
+            dataset: Which dataset to load — a 0-based index or a name (title,
+                run id or filename). Defaults to the first dataset.
 
         Raises:
             FileNotFoundError: If the file doesn't exist
             ValueError: If the data cannot be loaded or is invalid
         """
-        self.data = load_sans_data(filename)
+        self.data = load_sans_data(filename, dataset=dataset)
         self._full_q_range = (self.data.qmin, self.data.qmax)
 
         has_dy = has_real_data(self.data.dy)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -34,6 +34,48 @@ def create_loading_test_data_file_with_resolution(num_points=10):
     return temp_file.name
 
 
+def create_multi_dataset_xml_file(num_points=3):
+    """Write a CanSAS XML containing two datasets and return its path.
+
+    Dataset 0 has title "alpha sample" and run id "alpha_run"; dataset 1 has
+    title "beta sample" and run id "beta_run". Both share the same Q grid.
+    """
+    points = '\n'.join(
+        f'<Idata><Q unit="1/A">{q}</Q><I unit="1/cm">{i}</I>'
+        f'<Idev unit="1/cm">{di}</Idev></Idata>'
+        for q, i, di in (
+            ('0.01', '100', '10'),
+            ('0.02', '50', '5'),
+            ('0.03', '20', '2'),
+        )[:num_points]
+    )
+    xml = f'''<?xml version="1.0"?>
+<SASroot version="1.0"
+    xmlns="cansas1d/1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="cansas1d/1.0 http://svn.smallangles.net/svn/canSAS/1dwg/trunk/cansas1d.xsd">
+<SASentry>
+  <Title>alpha sample</Title>
+  <Run>alpha_run</Run>
+  <SASdata>
+    {points}
+  </SASdata>
+</SASentry>
+<SASentry>
+  <Title>beta sample</Title>
+  <Run>beta_run</Run>
+  <SASdata>
+    {points}
+  </SASdata>
+</SASentry>
+</SASroot>
+'''
+    temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.xml', delete=False)
+    temp_file.write(xml)
+    temp_file.close()
+    return temp_file.name
+
+
 def create_background_data_file(num_points=10):
     """Flat background on the same Q grid as create_loading_test_data_file."""
     temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -41,15 +41,14 @@ def create_multi_dataset_xml_file(num_points=3):
     title "beta sample" and run id "beta_run". Both share the same Q grid.
     """
     points = '\n'.join(
-        f'<Idata><Q unit="1/A">{q}</Q><I unit="1/cm">{i}</I>'
-        f'<Idev unit="1/cm">{di}</Idev></Idata>'
+        f'<Idata><Q unit="1/A">{q}</Q><I unit="1/cm">{i}</I><Idev unit="1/cm">{di}</Idev></Idata>'
         for q, i, di in (
             ('0.01', '100', '10'),
             ('0.02', '50', '5'),
             ('0.03', '20', '2'),
         )[:num_points]
     )
-    xml = f'''<?xml version="1.0"?>
+    xml = f"""<?xml version="1.0"?>
 <SASroot version="1.0"
     xmlns="cansas1d/1.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -69,7 +68,7 @@ def create_multi_dataset_xml_file(num_points=3):
   </SASdata>
 </SASentry>
 </SASroot>
-'''
+"""
     temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.xml', delete=False)
     temp_file.write(xml)
     temp_file.close()

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,13 +1,15 @@
 import os
 import unittest
+import warnings
 
 import numpy as np
 
-from sans_fitter import SANSFitter
-from sans_fitter.data.loader import has_real_data
+from sans_fitter import SANSFitter, data_ops
+from sans_fitter.data.loader import has_real_data, load_sans_data
 from tests.helpers import (
     create_loading_test_data_file,
     create_loading_test_data_file_with_resolution,
+    create_multi_dataset_xml_file,
 )
 
 
@@ -79,6 +81,94 @@ class TestDataLoading(unittest.TestCase):
             self.assertEqual(len(self.fitter.data.mask), len(self.fitter.data.x))
             # No NaN values in our test data, so mask should be all False
             self.assertFalse(np.any(self.fitter.data.mask))
+        finally:
+            os.unlink(data_file)
+
+
+class TestMultiDatasetLoading(unittest.TestCase):
+    """Multi-dataset files: warning + selection by index/name (issue #50)."""
+
+    def test_single_dataset_file_does_not_warn(self):
+        data_file = create_loading_test_data_file()
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter('always')
+                load_sans_data(data_file)
+            self.assertFalse(any('datasets' in str(w.message) for w in caught))
+        finally:
+            os.unlink(data_file)
+
+    def test_multi_dataset_file_warns_and_defaults_to_first(self):
+        data_file = create_multi_dataset_xml_file()
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter('always')
+                data = load_sans_data(data_file)
+            self.assertEqual(getattr(data, 'title', ''), 'alpha sample')
+            multi = [w for w in caught if 'datasets' in str(w.message)]
+            self.assertTrue(multi, 'expected a multi-dataset warning')
+            message = str(multi[0].message)
+            self.assertIn('alpha sample', message)
+            self.assertIn('beta sample', message)
+        finally:
+            os.unlink(data_file)
+
+    def test_multi_dataset_file_select_by_index(self):
+        data_file = create_multi_dataset_xml_file()
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                second = load_sans_data(data_file, dataset=1)
+            self.assertEqual(getattr(second, 'title', ''), 'beta sample')
+        finally:
+            os.unlink(data_file)
+
+    def test_multi_dataset_file_select_by_name(self):
+        data_file = create_multi_dataset_xml_file()
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                by_title = load_sans_data(data_file, dataset='beta sample')
+                by_run = load_sans_data(data_file, dataset='alpha_run')
+            self.assertEqual(getattr(by_title, 'title', ''), 'beta sample')
+            self.assertEqual(getattr(by_run, 'title', ''), 'alpha sample')
+        finally:
+            os.unlink(data_file)
+
+    def test_select_index_out_of_range_raises(self):
+        data_file = create_multi_dataset_xml_file()
+        try:
+            with self.assertRaises(ValueError):
+                load_sans_data(data_file, dataset=5)
+        finally:
+            os.unlink(data_file)
+
+    def test_select_unknown_name_raises(self):
+        data_file = create_multi_dataset_xml_file()
+        try:
+            with self.assertRaises(ValueError):
+                load_sans_data(data_file, dataset='no such dataset')
+        finally:
+            os.unlink(data_file)
+
+    def test_data_ops_load_passes_dataset_through(self):
+        data_file = create_multi_dataset_xml_file()
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                second = data_ops.load(data_file, dataset=1)
+            self.assertEqual(getattr(second, 'title', ''), 'beta sample')
+        finally:
+            os.unlink(data_file)
+
+    def test_fitter_load_data_accepts_dataset(self):
+        data_file = create_multi_dataset_xml_file()
+        try:
+            fitter = SANSFitter()
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                fitter.load_data(data_file, dataset='beta sample')
+            self.assertEqual(getattr(fitter.data, 'title', ''), 'beta sample')
         finally:
             os.unlink(data_file)
 


### PR DESCRIPTION
**Multi-dataset file support:**

* The `load_sans_data`, `data_ops.load`, and `SANSFitter.load_data` functions now accept a `dataset` argument, allowing selection of a specific dataset by 0-based index or by name (title, run id, or filename). A warning is issued if the file contains multiple datasets, listing all available options. 
* Helper functions (`_load_all`, `_dataset_names`, `_dataset_label`, `_select_dataset`) were added to resolve dataset selection and provide informative error messages if selection fails or is ambiguous.

