### PR TITLE
make radius_effective linkable in the standard way

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -291,6 +291,11 @@ When using a structure factor, you often need to define an effective radius. You
 fitter.set_structure_factor('hardsphere', radius_effective_mode='link_radius')
 ```
 
+This is an ordinary parameter link (see [Linking parameters](#combining-models-composite-models)):
+`get_links()` reports it as `{'radius_effective': 'radius'}`, `radius_effective`
+is held at `radius` throughout the fit, and writing to it directly raises. Pass
+`radius_effective_mode='unconstrained'` (the default) to fit it independently.
+
 ### Combining Models (Composite Models)
 
 Datasets with several distinct features — for example a low-Q diffuse
@@ -395,9 +400,9 @@ fitter.set_model('dab+peak_lorentz')   # A_scale, A_cor_length, B_scale, ...
 Every atomic name in the expression is validated before loading, with a
 nearest-match suggestion for typos.
 
-**Engine support.** Composite models and parameter links currently work with
-the `bumps` engine only; `fit(engine='lmfit')` and `fit_bayesian()` raise
-`NotImplementedError` when either is active.
+**Engine support.** Composite models currently work with the `bumps` engine
+only; `fit(engine='lmfit')` and `fit_bayesian()` raise `NotImplementedError`
+when one is active. Parameter links themselves work with every engine.
 
 See `examples/composite_model_example.py` for a complete runnable example.
 

--- a/src/sans_fitter/fitter.py
+++ b/src/sans_fitter/fitter.py
@@ -457,6 +457,11 @@ class SANSFitter:
         parameters, including cross-component ones (``'large_sld'`` following
         ``'small_sld'``) and differently named ones.
 
+        This is the same mechanism as
+        ``set_structure_factor(..., radius_effective_mode='link_radius')``,
+        which links ``'radius_effective'`` to ``'radius'``; ``get_links()``
+        reports both alike.
+
         Args:
             name: The follower parameter name.
             to: The target parameter name.
@@ -925,8 +930,8 @@ class SANSFitter:
 
         Raises:
             ValueError: If data or model not loaded, or invalid engine
-            NotImplementedError: If a composite model or parameter links are
-                used with an engine other than 'bumps'.
+            NotImplementedError: If a composite model is used with an engine
+                other than 'bumps'.
         """
         if self.data is None:
             raise ValueError('No data loaded. Use load_data() first.')
@@ -947,20 +952,17 @@ class SANSFitter:
         return self._fit_lmfit(method or 'leastsq', **kwargs)
 
     def _check_composite_engine_support(self, engine: str) -> None:
-        """Gate composite models and parameter links to the bumps engine.
+        """Gate composite models to the bumps engine.
 
         The scipy path would probably work for composites (DirectModel accepts
         prefixed kwargs) but it is untested; failing loudly beats silently
-        unvalidated results. A model using shared= always presents non-empty
-        linked_params, so no separate gate is needed for it.
+        unvalidated results. Parameter links are *not* gated: both engines apply
+        them on every model evaluation. shared= needs no gate of its own — it
+        only exists on composite models, which this check already covers.
         """
         if engine == 'bumps':
             return
         snapshot = self._param_manager.snapshot_fit_state()
-        if snapshot.linked_params:
-            raise NotImplementedError(
-                "Parameter links are currently supported by the 'bumps' engine only."
-            )
         if snapshot.components:
             raise NotImplementedError(
                 "Composite models are currently supported by the 'bumps' engine only."
@@ -1086,8 +1088,8 @@ class SANSFitter:
 
         Raises:
             ValueError: If data or model is not loaded, or no parameter varies.
-            NotImplementedError: If a composite model or parameter links are
-                used — the DREAM path does not support them yet.
+            NotImplementedError: If a composite model is used — the DREAM path
+                does not support them yet.
         """
         if self.data is None:
             raise ValueError('No data loaded. Use load_data() first.')
@@ -1095,10 +1097,10 @@ class SANSFitter:
             raise ValueError('No model loaded. Use set_model() first.')
 
         snapshot = self._param_manager.snapshot_fit_state()
-        if snapshot.linked_params or snapshot.components:
+        if snapshot.components:
             raise NotImplementedError(
-                'Composite models and parameter links are currently supported '
-                "by the 'bumps' point-estimate engine only (fit(engine='bumps'))."
+                "Composite models are currently supported by the 'bumps' "
+                "point-estimate engine only (fit(engine='bumps'))."
             )
         self._check_scale_degeneracy()
 

--- a/src/sans_fitter/fitting/base.py
+++ b/src/sans_fitter/fitting/base.py
@@ -24,24 +24,20 @@ def extract_fit_index(source: Any) -> np.ndarray | None:
     return np.asarray(index, dtype=bool)
 
 
-def link_radius_effective_model(model: Any, radius_effective_mode: str) -> None:
-    """Link radius_effective to radius on mutable model objects when requested."""
-    if (
-        radius_effective_mode == 'link_radius'
-        and hasattr(model, 'radius_effective')
-        and hasattr(model, 'radius')
-    ):
-        model.radius_effective = model.radius
+def apply_parameter_links(parameters: dict[str, Any], linked_params: dict[str, str]) -> None:
+    """Force every link follower to its target's value in a parameter dict.
 
+    The dict-level counterpart of the bumps engine's parameter-object aliasing,
+    used by evaluation paths that speak plain sasmodels kwargs (the scipy
+    residual, the DREAM posterior evaluator). It must run on *every* evaluation:
+    followers carry a stale value once the optimizer moves their target.
 
-def link_radius_effective_dict(parameters: dict[str, Any], radius_effective_mode: str) -> None:
-    """Link radius_effective to radius in parameter dictionaries when requested."""
-    if (
-        radius_effective_mode == 'link_radius'
-        and 'radius' in parameters
-        and 'radius_effective' in parameters
-    ):
-        parameters['radius_effective'] = parameters['radius']
+    The link graph has depth 1 (no target is itself a follower), so the order of
+    assignment does not matter. ``ParameterManager`` guarantees that invariant.
+    """
+    for follower, target in linked_params.items():
+        if follower in parameters and target in parameters:
+            parameters[follower] = parameters[target]
 
 
 @dataclass(slots=True)

--- a/src/sans_fitter/fitting/bumps_engine.py
+++ b/src/sans_fitter/fitting/bumps_engine.py
@@ -24,9 +24,8 @@ from ..results import (
 )
 from .base import (
     EngineFitOutput,
+    apply_parameter_links,
     extract_fit_index,
-    link_radius_effective_dict,
-    link_radius_effective_model,
     pd_is_active,
 )
 
@@ -82,13 +81,11 @@ def _build_bumps_problem(
             if pd_is_active(pd_config) and pd_config.get('vary', False):
                 getattr(model, f'{param_name}_pd').range(0, 1)
 
-    link_radius_effective_model(model, fit_state.radius_effective_mode)
-
-    # Generic equality links (composite models / shared= / link_params):
-    # alias the follower's bumps parameter object to the target's, the exact
-    # mechanism the radius link uses. Followers are never in the varying set,
-    # so they don't appear in problem.labels(); their post-fit value comes
-    # from apply_fitted_values propagation, not from the engine.
+    # Equality links (radius_effective_mode='link_radius' / composite shared= /
+    # link_params): alias the follower's bumps parameter object to the target's.
+    # Followers are never in the varying set, so they don't appear in
+    # problem.labels(); their post-fit value comes from apply_fitted_values
+    # propagation, not from the engine.
     # Precondition: the link graph has depth 1 — no target is itself a
     # follower — so the aliasing below is independent of dict order.
     # ParameterManager guarantees this (link_params rejects chains in both
@@ -102,11 +99,6 @@ def _build_bumps_problem(
             'support. ParameterManager should have rejected this.'
         )
     for follower, target in fit_state.linked_params.items():
-        if follower == 'radius_effective' and fit_state.radius_effective_mode == 'link_radius':
-            raise ValueError(
-                "'radius_effective' is already linked to 'radius' by "
-                "radius_effective_mode='link_radius'. Remove one of the links."
-            )
         setattr(model, follower, getattr(model, target))
 
     experiment = Experiment(data=data, model=model)
@@ -313,7 +305,7 @@ def _build_posterior_evaluator(
     def model_eval(sample: dict[str, float]) -> np.ndarray:
         pars = dict(base_pars)
         pars.update(sample)
-        link_radius_effective_dict(pars, fit_state.radius_effective_mode)
+        apply_parameter_links(pars, fit_state.linked_params)
         return np.asarray(calculator(**pars))
 
     return posterior_data, model_eval

--- a/src/sans_fitter/fitting/scipy_engine.py
+++ b/src/sans_fitter/fitting/scipy_engine.py
@@ -5,7 +5,7 @@ import numpy as np
 from sasmodels.direct_model import DirectModel
 
 from ..results import FitArtifacts, FitResultContract, ParameterStateSnapshot
-from .base import EngineFitOutput, extract_fit_index, link_radius_effective_dict, pd_is_active
+from .base import EngineFitOutput, apply_parameter_links, extract_fit_index, pd_is_active
 
 try:
     from scipy.optimize import differential_evolution, least_squares, leastsq
@@ -81,7 +81,7 @@ def fit_scipy(
                     par_dict[f'{base_param}_pd_nsigma'] = pd_config['pd_nsigma']
                     par_dict[f'{base_param}_pd_type'] = pd_config['pd_type']
 
-        link_radius_effective_dict(par_dict, fit_state.radius_effective_mode)
+        apply_parameter_links(par_dict, fit_state.linked_params)
         return par_dict
 
     def residual(x: np.ndarray) -> np.ndarray:
@@ -124,6 +124,10 @@ def fit_scipy(
             f"Unknown method '{method}'. Use 'leastsq', 'least_squares', or 'differential_evolution'."
         )
 
+    # The parameter set the fit actually landed on: link followers carry their
+    # target's fitted value here, which their stale fit_state entry does not.
+    final_pars = build_parameter_dict(fitted_params)
+
     result_parameters: dict[str, dict[str, Any]] = {}
     fitted_values: dict[str, float] = {}
 
@@ -139,10 +143,16 @@ def fit_scipy(
 
     for name, info in fit_state.params.items():
         if name not in param_names:
+            value = final_pars.get(name, info['value'])
+            label = (
+                f'{value:.6g} (= {fit_state.linked_params[name]})'
+                if name in fit_state.linked_params
+                else f'{value:.6g} (fixed)'
+            )
             result_parameters[name] = {
-                'value': info['value'],
+                'value': value,
                 'stderr': 0.0,
-                'formatted': f'{info["value"]:.6g} (fixed)',
+                'formatted': label,
             }
 
     contract = FitResultContract(
@@ -151,7 +161,7 @@ def fit_scipy(
         chisq=chisq,
         parameters=result_parameters,
         artifacts=FitArtifacts(
-            fitted_curve=np.asarray(calculator(**build_parameter_dict(fitted_params))),
+            fitted_curve=np.asarray(calculator(**final_pars)),
             fit_index=extract_fit_index(calculator),
             raw_result=result,
         ),

--- a/src/sans_fitter/modeling/parameters.py
+++ b/src/sans_fitter/modeling/parameters.py
@@ -2,9 +2,10 @@
 Parameter Manager - Handles model parameter management for SANS fitting.
 
 This module encapsulates all parameter-related operations including initialization,
-validation, bounds management, structure factor parameter linking, polydispersity,
-composite-model component metadata, the friendly-name alias layer, and generic
-parameter equality links.
+validation, bounds management, polydispersity, composite-model component metadata,
+the friendly-name alias layer, and parameter equality links — including the
+'radius_effective' -> 'radius' constraint of radius_effective_mode='link_radius',
+which is an ordinary link rather than a special case.
 """
 
 import warnings
@@ -88,7 +89,7 @@ class ParameterManager:
     Manages model parameters for SANS fitting.
 
     Handles parameter initialization, validation, bounds management,
-    special logic for structure factor parameter linking, and polydispersity support.
+    equality links between parameters, and polydispersity support.
 
     Attributes:
         params: Dictionary of parameter configurations
@@ -111,7 +112,9 @@ class ParameterManager:
         self._components: list[tuple[str, str, str]] = []
         # _links: equality links, follower -> target, stored under whatever
         # names self.params uses (aliases on the set_models path, canonical
-        # names on the raw set_model path).
+        # names on the raw set_model path). Sources: link_params(), the shared=
+        # sugar of set_models(), and radius_effective_mode='link_radius' (which
+        # owns its 'radius_effective' entry — see update_for_product_model).
         self._links: dict[str, str] = {}
         # Alias layer (set_models path only): alias -> canonical name. Shared
         # parameters additionally map one alias to several canonical names.
@@ -648,14 +651,9 @@ class ParameterManager:
 
         if value is not None:
             self.params[resolved]['value'] = value
-            # Sync radius_effective when radius is updated in link_radius mode
-            if (
-                resolved == 'radius'
-                and self._radius_effective_mode == 'link_radius'
-                and 'radius_effective' in self.params
-            ):
-                self.params['radius_effective']['value'] = value
-            # Propagate to equality-link followers of this parameter.
+            # Propagate to equality-link followers of this parameter. In
+            # link_radius mode 'radius_effective' is one of them, so the
+            # structure-factor link needs no special case here.
             for follower, link_target in self._links.items():
                 if link_target == resolved:
                     self.params[follower]['value'] = value
@@ -706,8 +704,6 @@ class ParameterManager:
 
         def entry_line(name: str, info: dict[str, Any]) -> str:
             vary_str = '✓' if info['vary'] else '✗'
-            if name == 'radius_effective' and self._radius_effective_mode == 'link_radius':
-                vary_str = '→radius'
             if name in self._links:
                 vary_str = f'→{self._links[name]}'
             return (
@@ -761,9 +757,6 @@ class ParameterManager:
         print(f'{"-" * 80}')
         for name, info in params.items():
             vary_str = '✓' if info['vary'] else '✗'
-            # Show linked indicator for radius_effective in link_radius mode
-            if name == 'radius_effective' and self._radius_effective_mode == 'link_radius':
-                vary_str = '→radius'
             if name in self._links:
                 vary_str = f'→{self._links[name]}'
             print(
@@ -817,13 +810,26 @@ class ParameterManager:
         # Backup polydispersity state if not already done
         if not self._backed_up_pd_state:
             self.backup_pd_state()
+        previous_mode = self._radius_effective_mode
         self.params = self._sf_manager.apply(
             kernel=kernel,
             sf_name=structure_factor_name,
             re_mode=radius_effective_mode,
             current_params=self.params,
         )
+        # radius_effective_mode owns the 'radius_effective' -> 'radius' link:
+        # drop the outgoing mode's link before the incoming mode re-establishes
+        # it, so switching modes cannot leave a phantom behind. Dropping it here
+        # rather than in _prune_stale_links() keeps it silent — it is an
+        # expected consequence of the mode change, not a stale link.
+        if 'link_radius' in (previous_mode, self._radius_effective_mode):
+            self._links.pop('radius_effective', None)
         self._prune_stale_links()
+        # _sf_manager.apply() downgrades the mode to 'unconstrained' when either
+        # parameter is missing, so both are present whenever it still reads
+        # 'link_radius'.
+        if self._radius_effective_mode == 'link_radius':
+            self.link_params('radius_effective', 'radius')
 
     def remove_structure_factor(self) -> str:
         """
@@ -835,8 +841,14 @@ class ParameterManager:
         Raises:
             ValueError: If no structure factor is currently set
         """
+        was_linked = self._radius_effective_mode == 'link_radius'
         sf_name, restored_params = self._sf_manager.remove()
         self.params = restored_params
+        # The mode-owned link retires with the structure factor that created
+        # it; a link the user made themselves is left to _prune_stale_links(),
+        # which reports it.
+        if was_linked:
+            self._links.pop('radius_effective', None)
         self.restore_pd_state()
         self._prune_stale_links()
         return sf_name

--- a/src/sans_fitter/modeling/structure_factor.py
+++ b/src/sans_fitter/modeling/structure_factor.py
@@ -124,16 +124,18 @@ class StructureFactorManager:
                     'description': 'Constant background level',
                 }
 
-        if re_mode == 'link_radius':
-            if 'radius' in new_params and 'radius_effective' in new_params:
-                new_params['radius_effective']['value'] = new_params['radius']['value']
-                new_params['radius_effective']['vary'] = False
-            else:
-                warnings.warn(
-                    'Cannot link radius_effective to radius: one or both parameters not found. Using unconstrained mode.',
-                    stacklevel=3,
-                )
-                self._radius_effective_mode = 'unconstrained'
+        # The link itself is an ordinary equality link, established by
+        # ParameterManager after this rebuild; all that is decided here is
+        # whether the requested mode is achievable at all.
+        if re_mode == 'link_radius' and not (
+            'radius' in new_params and 'radius_effective' in new_params
+        ):
+            warnings.warn(
+                'Cannot link radius_effective to radius: one or both parameters '
+                'not found. Using unconstrained mode.',
+                stacklevel=3,
+            )
+            self._radius_effective_mode = 'unconstrained'
 
         return new_params
 

--- a/src/sans_fitter/results.py
+++ b/src/sans_fitter/results.py
@@ -22,12 +22,16 @@ class ParameterStateSnapshot:
     polydisperse_param_names: list[str]
     polydisperse_params: dict[str, dict[str, Any]]
     pd_enabled: bool
+    # Informational: the 'radius_effective' -> 'radius' constraint it describes
+    # is carried by linked_params like any other link, so engines read that
+    # instead of branching on this mode.
     radius_effective_mode: str
     structure_factor_name: str | None
     varying_params: list[str]
     varying_pd_params: list[str]
     # Equality links (follower -> target), canonical names. Populated by
-    # link_params() and by the shared= sugar of set_models().
+    # link_params(), by the shared= sugar of set_models(), and by
+    # radius_effective_mode='link_radius'.
     linked_params: dict[str, str] = field(default_factory=dict)
     # Composite-model components as (prefix, moniker, part_model_name)
     # triples; empty for atomic models.

--- a/tests/test_composite_models.py
+++ b/tests/test_composite_models.py
@@ -291,7 +291,7 @@ class TestCompositeFitRoundTrip(unittest.TestCase):
 
 
 class TestEngineGating(unittest.TestCase):
-    """Test 6: non-bumps engines reject composites and links."""
+    """Test 6: non-bumps engines reject composites (but do support links)."""
 
     def setUp(self):
         self.fitter = SANSFitter()
@@ -303,15 +303,24 @@ class TestEngineGating(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             self.fitter.fit(engine='lmfit')
 
-    def test_lmfit_with_links_raises(self):
+    def test_lmfit_with_links_is_supported(self):
+        # Links are applied on every model evaluation by both engines, so an
+        # atomic model carrying one is not gated to bumps.
         atomic = SANSFitter()
         atomic.set_data(make_composite_data())
         atomic.set_model('sphere')
         atomic.set_param('radius', vary=True)
-        atomic.set_param('sld', vary=True)
+        atomic.set_param('sld', value=2.0, vary=True)
         atomic.link_params('sld_solvent', to='sld')
-        with self.assertRaises(NotImplementedError):
-            atomic.fit(engine='lmfit')
+
+        result = atomic.fit(engine='lmfit', method='leastsq')
+
+        # The follower tracks the target through the fit, not just before it.
+        self.assertEqual(atomic.params['sld_solvent']['value'], atomic.params['sld']['value'])
+        self.assertEqual(
+            result['parameters']['sld_solvent']['value'],
+            result['parameters']['sld']['value'],
+        )
 
     def test_bayesian_on_composite_raises(self):
         with self.assertRaises(NotImplementedError):

--- a/tests/test_structure_factor.py
+++ b/tests/test_structure_factor.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import warnings
 
 from sans_fitter import SANSFitter
 from tests.helpers import create_concentrated_sphere_data_file
@@ -92,6 +93,55 @@ class TestStructureFactorLinkRadius(unittest.TestCase):
         self.assertEqual(self.fitter.params['radius_effective']['value'], 60.0)
         self.assertTrue(self.fitter.params['radius_effective']['vary'])
 
+    def test_link_radius_mode_registers_an_ordinary_link(self):
+        # link_radius is not a special case: it is reported by get_links() and
+        # reaches the engines through the snapshot like any other link.
+        self.fitter.set_structure_factor('hardsphere', radius_effective_mode='link_radius')
+
+        self.assertEqual(self.fitter.get_links(), {'radius_effective': 'radius'})
+        snapshot = self.fitter._param_manager.snapshot_fit_state()
+        self.assertEqual(snapshot.linked_params, {'radius_effective': 'radius'})
+        self.assertNotIn('radius_effective', snapshot.varying_params)
+
+    def test_unconstrained_mode_registers_no_link(self):
+        self.fitter.set_structure_factor('hardsphere', radius_effective_mode='unconstrained')
+        self.assertEqual(self.fitter.get_links(), {})
+
+    def test_link_radius_mode_rejects_direct_writes(self):
+        self.fitter.set_structure_factor('hardsphere', radius_effective_mode='link_radius')
+
+        with self.assertRaises(ValueError):
+            self.fitter.set_param('radius_effective', value=60.0)
+        with self.assertRaises(ValueError):
+            self.fitter.set_param('radius_effective', vary=True)
+
+    def test_link_radius_mode_rejects_a_duplicate_manual_link(self):
+        self.fitter.set_structure_factor('hardsphere', radius_effective_mode='link_radius')
+
+        with self.assertRaises(ValueError) as context:
+            self.fitter.link_params('radius_effective', to='radius')
+        self.assertIn('already linked', str(context.exception))
+
+    def test_switching_mode_drops_the_previous_link(self):
+        self.fitter.set_structure_factor('hardsphere', radius_effective_mode='link_radius')
+        self.fitter.set_structure_factor('squarewell', radius_effective_mode='unconstrained')
+
+        self.assertEqual(self.fitter.get_links(), {})
+        self.fitter.set_param('radius_effective', value=60.0, vary=True)
+        self.assertEqual(self.fitter.params['radius_effective']['value'], 60.0)
+
+    def test_removing_structure_factor_retires_the_link_silently(self):
+        self.fitter.set_structure_factor('hardsphere', radius_effective_mode='link_radius')
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            self.fitter.remove_structure_factor()
+
+        self.assertEqual(self.fitter.get_links(), {})
+        # The mode-owned link retires with its structure factor; only a link the
+        # user made themselves is reported as stale.
+        self.assertFalse([w for w in caught if 'link' in str(w.message).lower()])
+
 
 class TestStructureFactorRemoval(unittest.TestCase):
     """Test structure factor removal functionality."""
@@ -177,6 +227,47 @@ class TestStructureFactorFitting(unittest.TestCase):
 
         self.assertIsNotNone(result)
         self.assertIn('volfraction', result['parameters'])
+        # radius varies, so this only holds if the link was applied during the
+        # fit rather than merely at setup time.
+        self.assertEqual(
+            self.fitter.params['radius_effective']['value'],
+            self.fitter.params['radius']['value'],
+        )
+
+    def test_fit_with_hardsphere_link_radius_lmfit(self):
+        self.fitter.set_structure_factor('hardsphere', radius_effective_mode='link_radius')
+        self.fitter.set_param('volfraction', value=0.2, min=0.01, max=0.6, vary=True)
+
+        try:
+            result = self.fitter.fit(engine='lmfit', method='least_squares')
+        except ValueError as error:
+            if 'scipy is not installed' in str(error):
+                self.skipTest('scipy not installed')
+            raise
+
+        self.assertIsNotNone(result)
+        self.assertEqual(
+            self.fitter.params['radius_effective']['value'],
+            self.fitter.params['radius']['value'],
+        )
+        self.assertEqual(
+            result['parameters']['radius_effective']['value'],
+            result['parameters']['radius']['value'],
+        )
+
+    def test_fit_bayesian_with_link_radius(self):
+        self.fitter.set_structure_factor('hardsphere', radius_effective_mode='link_radius')
+        self.fitter.set_param('volfraction', value=0.2, min=0.0, max=0.6, vary=True)
+
+        result = self.fitter.fit_bayesian(samples=200, burn=10)
+
+        self.assertIsNotNone(result)
+        # The follower is constrained away, so it never enters the chain.
+        self.assertNotIn('radius_effective', self.fitter.get_posterior().labels)
+        self.assertEqual(
+            self.fitter.params['radius_effective']['value'],
+            self.fitter.params['radius']['value'],
+        )
 
     def test_fit_with_hardsphere_lmfit(self):
         self.fitter.set_structure_factor('hardsphere')


### PR DESCRIPTION
This pull request refactors and generalizes the parameter linking mechanism in the SANS fitter, making parameter equality links (such as `radius_effective` → `radius`) a first-class, engine-independent feature. It removes special-case logic for structure factor parameter linking, ensures links are consistently applied across all engines, and improves the clarity and maintainability of the codebase. Documentation and error messages are updated to reflect these changes.

**Parameter linking generalization and engine support:**

* Parameter links (including `radius_effective_mode='link_radius'`) are now handled as ordinary equality links, not as a special case, and are supported by all fitting engines, not just `bumps`. 
* The new `apply_parameter_links` function replaces the old special-case functions, ensuring that all parameter links are applied consistently in both the `scipy` and `bumps` engines. 

**Codebase simplification and maintenance:**

* Removed code paths and logic that treated `radius_effective` as a special parameter, including redundant synchronization and display logic. Parameter links are now managed uniformly via the `_links` dictionary in `ParameterManager`. 
* The lifecycle of the `radius_effective` link is now tied to the structure factor mode, ensuring correct creation and cleanup when switching modes or removing the structure factor. 
