### PR TITLE
replaced prints with proper logging

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -144,6 +144,30 @@ See the [Example Data](examples.md) guide for the full collection.
         - Example
 
 
+## Console output
+
+Methods such as `load_data`, `set_model` and `fit` report what they did through
+the `sans_fitter` logger rather than with `print`, so the running commentary can
+be turned off:
+
+```python
+import sans_fitter
+
+sans_fitter.set_verbosity('quiet')   # keep warnings, drop the progress messages
+sans_fitter.set_verbosity('info')    # back to the default
+```
+
+Tables you ask for explicitly — `get_params()`, `get_pd_params()`,
+`examples.describe()` — are printed either way; they are the result of the call
+rather than a side effect of it.
+
+::: sans_fitter.console
+    options:
+      show_root_heading: true
+      show_source: true
+      members:
+        - set_verbosity
+
 ## ParameterManager
 
 Internal class for managing model parameters and polydispersity settings.

--- a/src/sans_fitter/__init__.py
+++ b/src/sans_fitter/__init__.py
@@ -4,6 +4,7 @@ SANS Model Fitter - A flexible template for fitting SANS data with SasModels
 
 from . import examples
 from . import inversion as pr_inversion
+from .console import set_verbosity
 from .data import ops as data_ops
 from .fitter import SANSFitter, get_all_models
 from .inversion import InsufficientDataError, PrEstimationError, PrResult
@@ -18,6 +19,7 @@ __all__ = [
     'PD_DEFAULTS',
     'PD_DISTRIBUTION_TYPES',
     'get_all_models',
+    'set_verbosity',
     'FitResultContract',
     'data_ops',
     'examples',

--- a/src/sans_fitter/console.py
+++ b/src/sans_fitter/console.py
@@ -1,0 +1,120 @@
+"""Console output: the package logger and encoding-safe glyphs.
+
+Status messages that are a *side effect* of a call — data loaded, model set,
+fit finished — go through ``logging.getLogger('sans_fitter')`` instead of
+``print``, so a caller can turn them off::
+
+    import sans_fitter
+    sans_fitter.set_verbosity('quiet')
+
+The logger owns a stdout handler and does not propagate, so by default the
+output is byte-for-byte what the ``print`` calls produced and it does not
+duplicate into an application's own logging configuration. To hand it over to
+that configuration instead::
+
+    import logging
+    log = logging.getLogger('sans_fitter')
+    log.handlers.clear()
+    log.propagate = True
+
+Tables the user asks for explicitly (``display_params``, ``display_pd_params``,
+``examples.describe``) still ``print``: they *are* the result of the call
+rather than a side effect of it, so routing them through the logger would
+leave those methods doing nothing when the package is silenced.
+
+The glyph constants fall back to ASCII when the active stdout cannot encode
+them. A legacy Windows console (cp1252) has no ``✓``, ``χ``, ``→`` or ``⁻``,
+and printing them there raises ``UnicodeEncodeError``.
+"""
+
+import logging
+import sys
+from typing import Any
+
+LOGGER_NAME = 'sans_fitter'
+
+logger = logging.getLogger(LOGGER_NAME)
+
+
+class _StdoutHandler(logging.StreamHandler):
+    """A ``StreamHandler`` that resolves ``sys.stdout`` at emit time.
+
+    ``StreamHandler`` binds its stream at construction, which would miss every
+    later redirection: the Jupyter kernel's streams, pytest's capture,
+    ``contextlib.redirect_stdout``. Resolving per emit keeps the logger
+    behaving like the ``print`` calls it replaced.
+    """
+
+    @property
+    def stream(self) -> Any:
+        return sys.stdout
+
+    @stream.setter
+    def stream(self, value: Any) -> None:
+        """Ignore the stream ``StreamHandler.__init__`` tries to bind."""
+
+
+def _install_default_handler() -> None:
+    handler = _StdoutHandler()
+    handler.setFormatter(logging.Formatter('%(message)s'))
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+
+if not logger.handlers:
+    _install_default_handler()
+
+
+_LEVEL_ALIASES = {'quiet': logging.WARNING}
+
+
+def set_verbosity(level: int | str = 'info') -> None:
+    """Set how much SANS-fitter reports about what it is doing.
+
+    Args:
+        level: ``'quiet'`` to drop the progress messages and keep only
+            warnings, or any standard logging level as a name (``'info'``,
+            ``'debug'``, ``'warning'``, ``'error'``) or as an integer. Pass
+            ``logging.CRITICAL`` to suppress the warnings as well.
+
+    Raises:
+        ValueError: If *level* is not a recognized level name.
+    """
+    if isinstance(level, str):
+        resolved = _LEVEL_ALIASES.get(level.lower(), logging.getLevelName(level.upper()))
+        if not isinstance(resolved, int):
+            raise ValueError(
+                f"Unknown verbosity '{level}'. Use 'quiet', 'info', 'debug', "
+                "'warning', 'error', or a logging level number."
+            )
+        level = resolved
+    logger.setLevel(level)
+
+
+def _encodable(text: str) -> bool:
+    """Return True when the current stdout can encode *text*."""
+    encoding = getattr(sys.stdout, 'encoding', None) or 'utf-8'
+    try:
+        text.encode(encoding)
+    except (LookupError, UnicodeEncodeError):
+        return False
+    return True
+
+
+def _glyph(preferred: str, fallback: str) -> str:
+    return preferred if _encodable(preferred) else fallback
+
+
+#: Prefix marking a completed action in a status message.
+OK = _glyph('✓', '[ok]')
+#: Table cell for a varying parameter.
+YES = _glyph('✓', 'yes')
+#: Table cell for a fixed parameter.
+NO = _glyph('✗', 'no')
+#: Points a follower parameter at its link target.
+ARROW = _glyph('→', '->')
+#: Unit of Q.
+INVERSE_ANGSTROM = _glyph('Å⁻¹', '1/Ang')
+#: Goodness-of-fit symbol.
+CHI_SQUARED = _glyph('χ²', 'chi^2')

--- a/src/sans_fitter/examples.py
+++ b/src/sans_fitter/examples.py
@@ -587,11 +587,14 @@ def _describe_one(example: Example) -> None:
 
 
 class _maybe_silenced:
-    """Context manager that optionally swallows ``print`` output.
+    """Context manager that optionally swallows stdout.
 
-    ``SANSFitter`` reports progress with ``print``; a preset builder that calls
-    four of those methods would otherwise emit a wall of text before the user
-    has done anything.
+    ``SANSFitter`` reports progress through the package logger, which writes to
+    stdout; a preset builder that calls four of those methods would otherwise
+    emit a wall of text before the user has done anything. Redirecting stdout
+    rather than raising the logger level also covers anything sasmodels prints,
+    and leaves the caller's own :func:`~sans_fitter.set_verbosity` choice
+    untouched.
     """
 
     def __init__(self, active: bool):

--- a/src/sans_fitter/fitter.py
+++ b/src/sans_fitter/fitter.py
@@ -20,6 +20,7 @@ from sasmodels.core import load_model
 from sasmodels.direct_model import DirectModel
 
 from . import plotting
+from .console import ARROW, CHI_SQUARED, INVERSE_ANGSTROM, OK, logger
 from .data.loader import get_fit_index, has_real_data, load_sans_data, normalize_sans_data
 from .fitting import (
     DEFAULT_DREAM_BURN,
@@ -43,13 +44,13 @@ def get_all_models() -> list[str]:
 
     Returns:
         List of model names
+
+    Raises:
+        Exception: Whatever ``sasmodels.core.list_models()`` raises. A broken
+            sasmodels installation surfaces as an error rather than as an
+            empty model list.
     """
-    try:
-        all_models = core.list_models()
-        return sorted(all_models)
-    except Exception as e:
-        print(f'Error fetching models: {str(e)}')
-        return []
+    return sorted(core.list_models())
 
 
 def _validate_model_expression(model_name: str) -> None:
@@ -144,11 +145,13 @@ class SANSFitter:
         has_dy = has_real_data(self.data.dy)
         has_dx = has_real_data(self.data.dx)
 
-        print(f'✓ Loaded data from {filename}')
-        print(f'  Q range: {self.data.qmin:.4f} to {self.data.qmax:.4f} Å⁻¹')
-        print(f'  Data points: {len(self.data.x)}')
-        print(f'  Error (dI) column: {"yes" if has_dy else "no"}')
-        print(f'  Resolution (dQ) column: {"yes" if has_dx else "no"}')
+        logger.info(
+            f'{OK} Loaded data from {filename}\n'
+            f'  Q range: {self.data.qmin:.4f} to {self.data.qmax:.4f} {INVERSE_ANGSTROM}\n'
+            f'  Data points: {len(self.data.x)}\n'
+            f'  Error (dI) column: {"yes" if has_dy else "no"}\n'
+            f'  Resolution (dQ) column: {"yes" if has_dx else "no"}'
+        )
 
     def set_data(self, data: Any) -> None:
         """
@@ -196,11 +199,13 @@ class SANSFitter:
         has_dx = has_real_data(self.data.dx)
         label = getattr(data, 'title', '') or getattr(data, 'filename', '') or 'in-memory dataset'
 
-        print(f'✓ Data set: {label}')
-        print(f'  Q range: {self.data.qmin:.4f} to {self.data.qmax:.4f} Å⁻¹')
-        print(f'  Data points: {len(self.data.x)}')
-        print(f'  Error (dI) column: {"yes" if has_dy else "no"}')
-        print(f'  Resolution (dQ) column: {"yes" if has_dx else "no"}')
+        logger.info(
+            f'{OK} Data set: {label}\n'
+            f'  Q range: {self.data.qmin:.4f} to {self.data.qmax:.4f} {INVERSE_ANGSTROM}\n'
+            f'  Data points: {len(self.data.x)}\n'
+            f'  Error (dI) column: {"yes" if has_dy else "no"}\n'
+            f'  Resolution (dQ) column: {"yes" if has_dx else "no"}'
+        )
 
     def set_q_range(self, qmin: float | None = None, qmax: float | None = None) -> None:
         """
@@ -245,8 +250,10 @@ class SANSFitter:
                 f'No data points in Q range [{new_qmin:g}, {new_qmax:g}]. Range unchanged.'
             )
 
-        print(f'✓ Q range for fitting: {new_qmin:.6g} to {new_qmax:.6g} Å⁻¹')
-        print(f'  Points in fit: {n_points} of {len(index)}')
+        logger.info(
+            f'{OK} Q range for fitting: {new_qmin:.6g} to {new_qmax:.6g} {INVERSE_ANGSTROM}\n'
+            f'  Points in fit: {n_points} of {len(index)}'
+        )
 
     def reset_q_range(self) -> None:
         """
@@ -260,8 +267,10 @@ class SANSFitter:
 
         self.data.qmin, self.data.qmax = self._full_q_range
         n_points = int(get_fit_index(self.data).sum())
-        print(f'✓ Q range reset to {self.data.qmin:.6g} to {self.data.qmax:.6g} Å⁻¹')
-        print(f'  Points in fit: {n_points}')
+        logger.info(
+            f'{OK} Q range reset to {self.data.qmin:.6g} to {self.data.qmax:.6g} '
+            f'{INVERSE_ANGSTROM}\n  Points in fit: {n_points}'
+        )
 
     def get_q_range(self) -> tuple[float, float] | None:
         """
@@ -306,8 +315,10 @@ class SANSFitter:
             # string (robust against nested mixture plugins).
             self._param_manager.initialize_from_kernel(self.kernel, model_name)
 
-            print(f"✓ Model '{model_name}' loaded successfully")
-            print(f'  Available parameters: {len(self._param_manager.params)}')
+            logger.info(
+                f"{OK} Model '{model_name}' loaded successfully\n"
+                f'  Available parameters: {len(self._param_manager.params)}'
+            )
 
         except Exception as e:
             raise ValueError(f"Failed to load model '{model_name}': {str(e)}") from e
@@ -441,11 +452,14 @@ class SANSFitter:
         # full alias map, not by ad-hoc string rules).
         self._param_manager.register_aliases(components, list(shared))
 
-        print(f'✓ Combined {len(components)} models: {expression}')
-        print(f'  Components: {", ".join(m for m, _n in components)}')
+        lines = [
+            f'{OK} Combined {len(components)} models: {expression}',
+            f'  Components: {", ".join(m for m, _n in components)}',
+        ]
         if shared:
-            print(f'  Shared parameters: {", ".join(shared)}')
-        print(f'  Available parameters: {len(self._param_manager.params)}')
+            lines.append(f'  Shared parameters: {", ".join(shared)}')
+        lines.append(f'  Available parameters: {len(self._param_manager.params)}')
+        logger.info('\n'.join(lines))
 
     def link_params(self, name: str, to: str) -> None:
         """
@@ -466,7 +480,7 @@ class SANSFitter:
             ValueError: On self-links, link chains, or conflicting links.
         """
         self._param_manager.link_params(name, to)
-        print(f'✓ Linked {name} → {to}')
+        logger.info(f'{OK} Linked {name} {ARROW} {to}')
 
     def unlink_params(self, name: str) -> None:
         """
@@ -480,7 +494,7 @@ class SANSFitter:
             ValueError: If the parameter is not linked.
         """
         self._param_manager.unlink_params(name)
-        print(f'✓ Unlinked {name}')
+        logger.info(f'{OK} Unlinked {name}')
 
     def get_links(self) -> dict[str, str]:
         """Return the active parameter equality links (follower -> target)."""
@@ -614,12 +628,15 @@ class SANSFitter:
                 self.kernel, structure_factor_name, radius_effective_mode
             )
 
+            lines = []
             if radius_effective_mode == 'link_radius':
-                print("  Note: 'radius_effective' linked to 'radius' value")
-
-            print(f"✓ Structure factor '{structure_factor_name}' applied to '{self.model_name}'")
-            print(f'  Product model: {full_model_name}')
-            print(f'  Total parameters: {len(self.params)}')
+                lines.append("  Note: 'radius_effective' linked to 'radius' value")
+            lines.append(
+                f"{OK} Structure factor '{structure_factor_name}' applied to '{self.model_name}'"
+            )
+            lines.append(f'  Product model: {full_model_name}')
+            lines.append(f'  Total parameters: {len(self.params)}')
+            logger.info('\n'.join(lines))
 
         except Exception as e:
             raise ValueError(f"Failed to load model '{full_model_name}': {str(e)}") from e
@@ -641,8 +658,10 @@ class SANSFitter:
             # Delegate to ParameterManager - this restores params and PD state
             sf_name = self._param_manager.remove_structure_factor()
 
-            print(f"✓ Structure factor '{sf_name}' removed")
-            print(f'  Reverted to form factor: {self.model_name}')
+            logger.info(
+                f"{OK} Structure factor '{sf_name}' removed\n"
+                f'  Reverted to form factor: {self.model_name}'
+            )
 
         except Exception as e:
             raise ValueError(f'Failed to reload form factor model: {str(e)}') from e
@@ -787,16 +806,19 @@ class SANSFitter:
         self.fit_result = self._fit_contract.to_legacy_dict()
         self._fitted_model = engine_output.runtime_model
 
-        print('\n✓ Fit completed!')
-        print(f'Final χ² = {self.fit_result["chisq"]:.4f}')
-        print('\nFitted parameters:')
+        lines = [
+            f'\n{OK} Fit completed!',
+            f'Final {CHI_SQUARED} = {self.fit_result["chisq"]:.4f}',
+            '\nFitted parameters:',
+        ]
         for name, info in self.fit_result['parameters'].items():
-            print(f'  {name}: {info["formatted"]}')
+            lines.append(f'  {name}: {info["formatted"]}')
 
         posterior = self._fit_contract.artifacts.posterior
         if posterior is not None:
-            print()
-            print(posterior.format_summary())
+            lines.append('')
+            lines.append(posterior.format_summary())
+        logger.info('\n'.join(lines))
 
         return self.fit_result
 
@@ -1303,4 +1325,4 @@ class SANSFitter:
             fit_result=fit_contract,
         )
 
-        print(f'✓ Results saved to {filename}')
+        logger.info(f'{OK} Results saved to {filename}')

--- a/src/sans_fitter/fitting/bumps_engine.py
+++ b/src/sans_fitter/fitting/bumps_engine.py
@@ -14,6 +14,7 @@ from sasmodels.bumps_model import Experiment
 from sasmodels.bumps_model import Model as BumpsModel
 from sasmodels.direct_model import DirectModel
 
+from ..console import CHI_SQUARED, logger
 from ..results import (
     MIN_POSTERIOR_PARAMETER_COUNT,
     MIN_POSTERIOR_SAMPLE_COUNT,
@@ -124,8 +125,9 @@ def fit_bumps(
     """Fit using the BUMPS engine."""
     problem, experiment = _build_bumps_problem(data, kernel, fit_state)
 
-    print(f'\nInitial χ² = {problem.chisq():.4f}')
-    print(f'Fitting with BUMPS (method: {method})...')
+    logger.info(
+        f'\nInitial {CHI_SQUARED} = {problem.chisq():.4f}\nFitting with BUMPS (method: {method})...'
+    )
 
     result = bumps_fit(problem, method=method, **kwargs)
 
@@ -346,8 +348,10 @@ def fit_bumps_dream(
             'Use set_param(..., vary=True) before fit_bayesian().'
         )
 
-    print(f'\nInitial χ² = {problem.chisq():.4f}')
-    print(f'Sampling posterior with BUMPS DREAM (samples={samples}, burn={burn} generations)...')
+    logger.info(
+        f'\nInitial {CHI_SQUARED} = {problem.chisq():.4f}\n'
+        f'Sampling posterior with BUMPS DREAM (samples={samples}, burn={burn} generations)...'
+    )
 
     result = bumps_fit(
         problem, method=method, samples=samples, burn=burn, thin=thin, pop=pop, **kwargs

--- a/src/sans_fitter/fitting/scipy_engine.py
+++ b/src/sans_fitter/fitting/scipy_engine.py
@@ -4,6 +4,7 @@ from typing import Any
 import numpy as np
 from sasmodels.direct_model import DirectModel
 
+from ..console import logger
 from ..results import FitArtifacts, FitResultContract, ParameterStateSnapshot
 from .base import EngineFitOutput, extract_fit_index, link_radius_effective_dict, pd_is_active
 
@@ -88,7 +89,7 @@ def fit_scipy(
         i_calc = calculator(**build_parameter_dict(x))
         return (y_fit - i_calc) / dy_fit
 
-    print(f'\nFitting with scipy.optimize (method: {method})...')
+    logger.info(f'\nFitting with scipy.optimize (method: {method})...')
 
     if method == 'leastsq':
         result = leastsq(residual, x0, full_output=True, **kwargs)

--- a/src/sans_fitter/modeling/parameters.py
+++ b/src/sans_fitter/modeling/parameters.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import numpy as np
 
+from ..console import ARROW, NO, YES
 from ..results import ParameterStateSnapshot
 from .polydispersity import PolydispersityManager
 from .structure_factor import StructureFactorManager, default_parameter_bounds
@@ -705,11 +706,11 @@ class ParameterManager:
         shared_names = set(self._shared_to_canonicals.keys())
 
         def entry_line(name: str, info: dict[str, Any]) -> str:
-            vary_str = '✓' if info['vary'] else '✗'
+            vary_str = YES if info['vary'] else NO
             if name == 'radius_effective' and self._radius_effective_mode == 'link_radius':
-                vary_str = '→radius'
+                vary_str = f'{ARROW}radius'
             if name in self._links:
-                vary_str = f'→{self._links[name]}'
+                vary_str = f'{ARROW}{self._links[name]}'
             return (
                 f'{name:<28} {info["value"]:<12.4g} {info["min"]:<12.4g} '
                 f'{info["max"]:<12.4g} {vary_str:<8}'
@@ -760,12 +761,12 @@ class ParameterManager:
         print(f'{"Parameter":<20} {"Value":<12} {"Min":<12} {"Max":<12} {"Vary":<8}')
         print(f'{"-" * 80}')
         for name, info in params.items():
-            vary_str = '✓' if info['vary'] else '✗'
+            vary_str = YES if info['vary'] else NO
             # Show linked indicator for radius_effective in link_radius mode
             if name == 'radius_effective' and self._radius_effective_mode == 'link_radius':
-                vary_str = '→radius'
+                vary_str = f'{ARROW}radius'
             if name in self._links:
-                vary_str = f'→{self._links[name]}'
+                vary_str = f'{ARROW}{self._links[name]}'
             print(
                 f'{name:<20} {info["value"]:<12.4g} {info["min"]:<12.4g} '
                 f'{info["max"]:<12.4g} {vary_str:<8}'

--- a/src/sans_fitter/modeling/polydispersity.py
+++ b/src/sans_fitter/modeling/polydispersity.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from ..console import NO, YES
+
 PD_DEFAULTS = {
     'pd': 0.0,
     'pd_n': 35,
@@ -175,7 +177,7 @@ class PolydispersityManager:
         for param_name in self._param_names:
             pd_config = self._params[param_name]
             display_name = (name_map or {}).get(param_name, param_name)
-            vary_str = '✓' if pd_config.get('vary', False) else '✗'
+            vary_str = YES if pd_config.get('vary', False) else NO
             print(
                 f'{display_name:<20} {pd_config["pd"]:<10.4g} {pd_config["pd_n"]:<10} '
                 f'{pd_config["pd_nsigma"]:<10.4g} {pd_config["pd_type"]:<12} {vary_str:<8}'

--- a/src/sans_fitter/plotting.py
+++ b/src/sans_fitter/plotting.py
@@ -6,6 +6,7 @@ import numpy as np
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
+from .console import logger
 from .data.loader import has_real_data
 from .results import (
     MIN_POSTERIOR_PARAMETER_COUNT,
@@ -102,7 +103,7 @@ def plot_fit(
     error_x = _error_bars(data.dx)
 
     if fit_result is None:
-        print('No fit results available. Plotting data only.')
+        logger.warning('No fit results available. Plotting data only.')
         fig = go.Figure()
         fig.add_trace(
             go.Scatter(

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,135 @@
+"""Progress reporting goes through the package logger, not bare ``print``.
+
+Two properties are pinned here: the messages a call emits as a side effect can
+be silenced (``set_verbosity``), and the glyphs those messages carry never
+reach a console that cannot encode them.
+"""
+
+import io
+import logging
+import sys
+
+import pytest
+
+import sans_fitter
+from sans_fitter import SANSFitter, console
+
+
+@pytest.fixture(autouse=True)
+def restore_verbosity():
+    """Keep a test's verbosity change from leaking into the rest of the suite."""
+    previous = console.logger.level
+    yield
+    console.logger.setLevel(previous)
+
+
+class _FakeStream:
+    """Minimal stdout stand-in: ``_encodable`` only reads ``encoding``."""
+
+    def __init__(self, encoding):
+        self.encoding = encoding
+
+
+class TestVerbosity:
+    def test_progress_is_reported_by_default(self, capsys):
+        SANSFitter().set_model('sphere')
+        assert 'sphere' in capsys.readouterr().out
+
+    def test_quiet_suppresses_progress(self, capsys):
+        sans_fitter.set_verbosity('quiet')
+        SANSFitter().set_model('sphere')
+        assert capsys.readouterr().out == ''
+
+    def test_verbosity_can_be_turned_back_on(self, capsys):
+        sans_fitter.set_verbosity('quiet')
+        sans_fitter.set_verbosity('info')
+        SANSFitter().set_model('sphere')
+        assert 'sphere' in capsys.readouterr().out
+
+    def test_quiet_keeps_warnings(self, capsys):
+        sans_fitter.set_verbosity('quiet')
+        console.logger.warning('kept')
+        assert 'kept' in capsys.readouterr().out
+
+    def test_critical_silences_warnings_too(self, capsys):
+        sans_fitter.set_verbosity(logging.CRITICAL)
+        console.logger.warning('dropped')
+        assert capsys.readouterr().out == ''
+
+    def test_integer_levels_are_accepted(self):
+        sans_fitter.set_verbosity(logging.DEBUG)
+        assert console.logger.level == logging.DEBUG
+
+    def test_unknown_level_is_rejected(self):
+        with pytest.raises(ValueError, match='Unknown verbosity'):
+            sans_fitter.set_verbosity('loud')
+
+
+class TestLoggerWiring:
+    def test_messages_do_not_duplicate_into_the_root_logger(self, capsys):
+        root_output = io.StringIO()
+        root_handler = logging.StreamHandler(root_output)
+        logging.getLogger().addHandler(root_handler)
+        try:
+            console.logger.info('once')
+        finally:
+            logging.getLogger().removeHandler(root_handler)
+
+        assert root_output.getvalue() == ''
+        assert capsys.readouterr().out == 'once\n'
+
+    def test_output_follows_stdout_redirection(self):
+        """The handler must resolve sys.stdout per emit, not bind it at import."""
+        import contextlib
+
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            console.logger.info('redirected')
+        assert buffer.getvalue() == 'redirected\n'
+
+
+class TestGlyphFallback:
+    """cp1252 (the legacy Windows console) cannot encode the preferred glyphs."""
+
+    def test_glyph_falls_back_when_stdout_cannot_encode_it(self, monkeypatch):
+        monkeypatch.setattr(sys, 'stdout', _FakeStream('cp1252'))
+        assert console._glyph('✓', '[ok]') == '[ok]'
+
+    def test_glyph_is_kept_when_stdout_can_encode_it(self, monkeypatch):
+        monkeypatch.setattr(sys, 'stdout', _FakeStream('utf-8'))
+        assert console._glyph('✓', '[ok]') == '✓'
+
+    def test_unknown_encoding_falls_back(self, monkeypatch):
+        monkeypatch.setattr(sys, 'stdout', _FakeStream('not-a-real-codec'))
+        assert console._glyph('✓', '[ok]') == '[ok]'
+
+    @pytest.mark.parametrize('glyph', ['✓', '✗', '→', 'Å⁻¹', 'χ²'])
+    def test_every_preferred_glyph_is_covered_by_a_fallback(self, glyph, monkeypatch):
+        monkeypatch.setattr(sys, 'stdout', _FakeStream('cp1252'))
+        assert not console._encodable(glyph)
+
+    def test_selected_glyphs_are_printable_on_this_console(self):
+        for glyph in (
+            console.OK,
+            console.YES,
+            console.NO,
+            console.ARROW,
+            console.INVERSE_ANGSTROM,
+            console.CHI_SQUARED,
+        ):
+            assert console._encodable(glyph), glyph
+
+    def test_status_messages_use_the_selected_glyphs(self, capsys):
+        SANSFitter().set_model('sphere')
+        assert capsys.readouterr().out.startswith(console.OK)
+
+    def test_parameter_table_uses_the_selected_glyphs(self, capsys):
+        fitter = SANSFitter()
+        fitter.set_model('sphere')
+        fitter.set_param('radius', vary=True)
+        capsys.readouterr()
+
+        fitter.get_params()
+        table = capsys.readouterr().out
+        assert console.YES in table
+        assert console.NO in table

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -23,6 +23,7 @@ class TestPublicApi(unittest.TestCase):
             'PD_DEFAULTS',
             'PD_DISTRIBUTION_TYPES',
             'get_all_models',
+            'set_verbosity',
             'FitResultContract',
             'PosteriorSummary',
             'data_ops',

--- a/tests/test_sans_fitter.py
+++ b/tests/test_sans_fitter.py
@@ -36,6 +36,16 @@ class TestGetAllModels(unittest.TestCase):
         models = get_all_models()
         self.assertEqual(models, sorted(models))
 
+    def test_get_all_models_propagates_sasmodels_failures(self):
+        """A broken sasmodels must not masquerade as 'no models installed'."""
+        from unittest.mock import patch
+
+        from sans_fitter import fitter as fitter_module
+
+        with patch.object(fitter_module.core, 'list_models', side_effect=RuntimeError('boom')):
+            with self.assertRaises(RuntimeError):
+                fitter_module.get_all_models()
+
 
 class TestSANSFitterInitialization(unittest.TestCase):
     """Test SANSFitter initialization."""


### PR DESCRIPTION
**Console and Logging System Overhaul:**

* Added a new `console.py` module that defines a package logger (`sans_fitter`), encoding-safe glyph constants (e.g., `✓`, `χ²`), and a `set_verbosity` function to control logging output. The logger writes to `sys.stdout` and can be integrated with user logging configurations.
* All status and progress messages in `SANSFitter` methods and fitting engines are now routed through the logger instead of `print`, using the new glyphs for improved readability.
* 
**API and Documentation Updates:**

* Exposed `set_verbosity` at the package level for user control and documented its usage in `api.md`, clarifying the distinction between status messages and explicit output tables. 
* Updated the `_maybe_silenced` context manager to clarify that it now redirects stdout, covering both logger and any external prints, and to reflect the new logging approach. 

**Error Handling and API Consistency:**

* Simplified `get_all_models()` to raise exceptions directly from `sasmodels` rather than swallowing errors and returning an empty list, ensuring that installation issues are surfaced to the user

**Internal Refactoring:**

* Replaced all direct uses of `print` for status updates in the codebase with logger calls, ensuring consistent output and improved testability. (

**Console Output Enhancements:**

* Introduced encoding-safe glyphs (e.g., `✓`, `χ²`, `→`, `Å⁻¹`) with fallbacks for environments that cannot display them, improving the clarity and professionalism of console messages.
