### PR TITLE
Fit result schema standardization

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -76,6 +76,37 @@ LMFit provides access to SciPy's optimization algorithms.
 result = fitter.fit(engine='lmfit', method='leastsq')
 ```
 
+#### Reading the result
+
+Both engines return the same structure, so code written against one works
+against the other:
+
+```python
+result['engine']      # 'bumps' or 'lmfit'
+result['method']      # the optimization method used
+result['chisq']       # goodness of fit
+result['parameters']  # one entry per model parameter
+```
+
+Each entry in `result['parameters']` carries the same five fields:
+
+| Field | Meaning |
+|---|---|
+| `value` | Fitted value, or the value the parameter was held at |
+| `stderr` | Uncertainty on a fitted value; `0.0` for anything not fitted |
+| `formatted` | Display string, e.g. `45.041(46)`, `2 (fixed)`, `45.041 (linked)` |
+| `fixed` | `False` for the parameters the optimizer varied, `True` otherwise |
+| `linked_to` | Name of the parameter this one follows, or `None` |
+
+```python
+fitted = {name: info['value'] for name, info in result['parameters'].items()
+          if not info['fixed']}
+```
+
+A parameter that follows another one — through `link_params()` or
+`radius_effective_mode='link_radius'` — reports its target's *fitted* value and
+names that target in `linked_to`.
+
 ### 5. Visualization and Export
 
 After fitting, you can plot the results and save them.

--- a/src/sans_fitter/fitter.py
+++ b/src/sans_fitter/fitter.py
@@ -774,8 +774,10 @@ class SANSFitter:
         # Translate engine result names (canonical) back to user-facing names
         # so saved results and displays never expose A_/B_ on the set_models
         # path (Boundary 2 of the alias layer).
+        to_display = self._param_manager.to_display_name
         self._fit_contract.parameters = {
-            self._param_manager.to_display_name(name): dict(info)
+            to_display(name): dict(info)
+            | {'linked_to': to_display(info['linked_to']) if info['linked_to'] else None}
             for name, info in self._fit_contract.parameters.items()
         }
 
@@ -921,7 +923,12 @@ class SANSFitter:
             **kwargs: Additional arguments passed to the fitting engine
 
         Returns:
-            Dictionary with fit results including chi-squared and parameter values
+            Dictionary with ``engine``, ``method``, ``chisq`` and
+            ``parameters``. The ``parameters`` block is engine-independent:
+            one entry per model parameter, each carrying ``value``, ``stderr``,
+            ``formatted``, a ``fixed`` flag (``False`` only for the parameters
+            the optimizer varied) and ``linked_to`` (the parameter it follows,
+            or ``None``). A follower reports its target's fitted value.
 
         Raises:
             ValueError: If data or model not loaded, or invalid engine

--- a/src/sans_fitter/fitting/base.py
+++ b/src/sans_fitter/fitting/base.py
@@ -44,6 +44,56 @@ def link_radius_effective_dict(parameters: dict[str, Any], radius_effective_mode
         parameters['radius_effective'] = parameters['radius']
 
 
+def build_result_parameters(
+    fit_state: ParameterStateSnapshot,
+    varied: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Assemble the engine-independent ``parameters`` block of a fit result.
+
+    Every engine reports the same set — one entry per model parameter, plus any
+    polydispersity width the engine varied — so code written against one engine
+    keeps working against the other. Every entry carries the same four fields:
+    ``value``, ``stderr``, ``formatted``, a ``fixed`` flag separating the
+    optimizer's dimensions from the rest, and ``linked_to`` naming the parameter
+    it follows (``None`` when it follows none).
+
+    *varied* holds the engine's own entries for the parameters it optimized,
+    already formatted in that engine's uncertainty convention. Everything else
+    in ``fit_state.params`` is appended here. A parameter that follows another
+    one (``link_params`` or ``radius_effective_mode='link_radius'``) reports its
+    target's fitted value rather than the pre-fit value the snapshot carries.
+
+    Names here are canonical; ``linked_to`` is translated to the user-facing
+    alias alongside the keys, in ``SANSFitter._finalize_fit``.
+    """
+    parameters = {
+        name: {**info, 'fixed': False, 'linked_to': None} for name, info in varied.items()
+    }
+
+    followers = dict(fit_state.linked_params)
+    if fit_state.radius_effective_mode == 'link_radius' and 'radius_effective' in fit_state.params:
+        followers.setdefault('radius_effective', 'radius')
+
+    for name, info in fit_state.params.items():
+        if name in parameters:
+            continue
+        target = followers.get(name)
+        if target is not None and target in parameters:
+            # The target was fitted, so the snapshot's follower value is stale.
+            # A fixed target needs no correction: its value never moved.
+            value = parameters[target]['value']
+        else:
+            value = info['value']
+        parameters[name] = {
+            'value': value,
+            'stderr': 0.0,
+            'formatted': f'{value:.6g} ({"linked" if target else "fixed"})',
+            'fixed': True,
+            'linked_to': target,
+        }
+    return parameters
+
+
 @dataclass(slots=True)
 class EngineFitOutput:
     """Internal engine output used by SANSFitter to sync state after fitting."""

--- a/src/sans_fitter/fitting/bumps_engine.py
+++ b/src/sans_fitter/fitting/bumps_engine.py
@@ -24,6 +24,7 @@ from ..results import (
 )
 from .base import (
     EngineFitOutput,
+    build_result_parameters,
     extract_fit_index,
     link_radius_effective_dict,
     link_radius_effective_model,
@@ -129,11 +130,11 @@ def fit_bumps(
 
     result = bumps_fit(problem, method=method, **kwargs)
 
-    result_parameters: dict[str, dict[str, Any]] = {}
+    varied: dict[str, dict[str, Any]] = {}
     fitted_values: dict[str, float] = {}
 
     for name, value, stderr in zip(problem.labels(), result.x, result.dx, strict=True):
-        result_parameters[name] = {
+        varied[name] = {
             'value': value,
             'stderr': stderr,
             'formatted': format_uncertainty(value, stderr),
@@ -144,7 +145,7 @@ def fit_bumps(
         engine='bumps',
         method=method,
         chisq=problem.chisq(),
-        parameters=result_parameters,
+        parameters=build_result_parameters(fit_state, varied),
         artifacts=FitArtifacts(
             fitted_curve=np.asarray(experiment.theory()),
             fit_index=extract_fit_index(experiment),
@@ -365,13 +366,13 @@ def fit_bumps_dream(
     posterior = _extract_posterior(state, labels, point_estimate)
     posterior_data, posterior_model_eval = _build_posterior_evaluator(data, kernel, fit_state)
 
-    result_parameters: dict[str, dict[str, Any]] = {}
+    varied: dict[str, dict[str, Any]] = {}
     fitted_values: dict[str, float] = {}
 
     # For DREAM, result.dx is the posterior 68% credible half-width, so the
     # existing formatted-uncertainty convention carries over unchanged.
     for name, value, stderr in zip(labels, result.x, result.dx, strict=True):
-        result_parameters[name] = {
+        varied[name] = {
             'value': value,
             'stderr': stderr,
             'formatted': format_uncertainty(value, stderr),
@@ -382,7 +383,7 @@ def fit_bumps_dream(
         engine='bumps',
         method=method,
         chisq=chisq,
-        parameters=result_parameters,
+        parameters=build_result_parameters(fit_state, varied),
         artifacts=FitArtifacts(
             fitted_curve=fitted_curve,
             fit_index=extract_fit_index(experiment),

--- a/src/sans_fitter/fitting/scipy_engine.py
+++ b/src/sans_fitter/fitting/scipy_engine.py
@@ -5,7 +5,13 @@ import numpy as np
 from sasmodels.direct_model import DirectModel
 
 from ..results import FitArtifacts, FitResultContract, ParameterStateSnapshot
-from .base import EngineFitOutput, extract_fit_index, link_radius_effective_dict, pd_is_active
+from .base import (
+    EngineFitOutput,
+    build_result_parameters,
+    extract_fit_index,
+    link_radius_effective_dict,
+    pd_is_active,
+)
 
 try:
     from scipy.optimize import differential_evolution, least_squares, leastsq
@@ -124,11 +130,11 @@ def fit_scipy(
             f"Unknown method '{method}'. Use 'leastsq', 'least_squares', or 'differential_evolution'."
         )
 
-    result_parameters: dict[str, dict[str, Any]] = {}
+    varied: dict[str, dict[str, Any]] = {}
     fitted_values: dict[str, float] = {}
 
     for index, name in enumerate(param_names):
-        result_parameters[name] = {
+        varied[name] = {
             'value': fitted_params[index],
             'stderr': param_errors[index],
             'formatted': f'{fitted_params[index]:.6g} ± {param_errors[index]:.6g}'
@@ -137,19 +143,11 @@ def fit_scipy(
         }
         fitted_values[name] = fitted_params[index]
 
-    for name, info in fit_state.params.items():
-        if name not in param_names:
-            result_parameters[name] = {
-                'value': info['value'],
-                'stderr': 0.0,
-                'formatted': f'{info["value"]:.6g} (fixed)',
-            }
-
     contract = FitResultContract(
         engine='lmfit',
         method=method,
         chisq=chisq,
-        parameters=result_parameters,
+        parameters=build_result_parameters(fit_state, varied),
         artifacts=FitArtifacts(
             fitted_curve=np.asarray(calculator(**build_parameter_dict(fitted_params))),
             fit_index=extract_fit_index(calculator),

--- a/tests/test_result_schema.py
+++ b/tests/test_result_schema.py
@@ -1,0 +1,155 @@
+"""The fit_result parameter schema is the same for every engine (issue #30).
+
+Both engines must report one entry per model parameter with the same fields,
+so code written against one keeps working against the other. Before this,
+bumps reported only the parameters it varied while scipy reported varied and
+fixed ones, and neither said which was which.
+"""
+
+import contextlib
+import io
+import os
+import tempfile
+import unittest
+
+from sans_fitter import SANSFitter
+from tests.helpers import create_decay_data_file
+
+ENTRY_FIELDS = {'value', 'stderr', 'formatted', 'fixed', 'linked_to'}
+
+
+def configure(data_file, **structure_factor):
+    """A sphere fit with two varied and three fixed parameters."""
+    fitter = SANSFitter()
+    with contextlib.redirect_stdout(io.StringIO()):
+        fitter.load_data(data_file)
+        fitter.set_model('sphere')
+        fitter.set_param('radius', value=20.0, min=10.0, max=30.0, vary=True)
+        fitter.set_param('scale', value=0.1, min=0.01, max=1.0, vary=True)
+        fitter.set_param('background', value=0.01, vary=False)
+        fitter.set_param('sld', value=2.0, vary=False)
+        fitter.set_param('sld_solvent', value=3.0, vary=False)
+        if structure_factor:
+            fitter.set_structure_factor(**structure_factor)
+    return fitter
+
+
+def run_fit(fitter, engine, method):
+    with contextlib.redirect_stdout(io.StringIO()):
+        return fitter.fit(engine=engine, method=method)
+
+
+class TestSchemaMatchesAcrossEngines(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data_file = create_decay_data_file(num_points=20)
+        cls.results = {
+            'bumps': run_fit(configure(cls.data_file), 'bumps', 'amoeba'),
+            'lmfit': run_fit(configure(cls.data_file), 'lmfit', 'leastsq'),
+        }
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(cls.data_file):
+            os.unlink(cls.data_file)
+
+    def test_both_engines_report_the_same_parameters(self):
+        self.assertEqual(
+            set(self.results['bumps']['parameters']),
+            set(self.results['lmfit']['parameters']),
+        )
+
+    def test_every_model_parameter_is_reported(self):
+        expected = {'radius', 'scale', 'background', 'sld', 'sld_solvent'}
+        for engine, result in self.results.items():
+            self.assertEqual(set(result['parameters']), expected, engine)
+
+    def test_every_entry_carries_the_same_fields(self):
+        for engine, result in self.results.items():
+            for name, info in result['parameters'].items():
+                self.assertEqual(set(info), ENTRY_FIELDS, f'{engine}/{name}')
+
+    def test_both_engines_agree_on_which_parameters_varied(self):
+        varied = {
+            engine: {name for name, info in result['parameters'].items() if not info['fixed']}
+            for engine, result in self.results.items()
+        }
+        self.assertEqual(varied['bumps'], {'radius', 'scale'})
+        self.assertEqual(varied['bumps'], varied['lmfit'])
+
+    def test_fixed_parameters_keep_their_configured_value(self):
+        for engine, result in self.results.items():
+            self.assertEqual(result['parameters']['sld']['value'], 2.0, engine)
+            self.assertTrue(result['parameters']['sld']['fixed'], engine)
+            self.assertIn('fixed', result['parameters']['sld']['formatted'])
+
+    def test_unlinked_parameters_report_no_link(self):
+        for engine, result in self.results.items():
+            for name, info in result['parameters'].items():
+                self.assertIsNone(info['linked_to'], f'{engine}/{name}')
+
+    def test_fixed_parameters_are_exported(self):
+        for engine, method in (('bumps', 'amoeba'), ('lmfit', 'leastsq')):
+            fitter = configure(self.data_file)
+            with contextlib.redirect_stdout(io.StringIO()), tempfile.TemporaryDirectory() as tmpdir:
+                fitter.fit(engine=engine, method=method)
+                path = os.path.join(tmpdir, 'results.csv')
+                fitter.save_results(path)
+                with open(path) as handle:
+                    content = handle.read()
+            self.assertIn('# sld:', content, engine)
+            self.assertIn('# radius:', content, engine)
+
+
+class TestLinkedParametersInResults(unittest.TestCase):
+    """A follower must report its target's *fitted* value, not the pre-fit one."""
+
+    def setUp(self):
+        self.data_file = create_decay_data_file(num_points=20)
+
+    def tearDown(self):
+        if os.path.exists(self.data_file):
+            os.unlink(self.data_file)
+
+    def _linked_fitter(self):
+        fitter = SANSFitter()
+        with contextlib.redirect_stdout(io.StringIO()):
+            fitter.load_data(self.data_file)
+            fitter.set_models(small='sphere', big='sphere')
+            fitter.link_params('big_radius', 'small_radius')
+            fitter.set_param('small_radius', value=20.0, min=10.0, max=30.0, vary=True)
+        return fitter
+
+    def test_follower_tracks_the_fitted_target(self):
+        fitter = self._linked_fitter()
+        params = run_fit(fitter, 'bumps', 'amoeba')['parameters']
+        self.assertFalse(params['small_radius']['fixed'])
+        self.assertTrue(params['big_radius']['fixed'])
+        self.assertEqual(params['big_radius']['value'], params['small_radius']['value'])
+
+    def test_follower_names_its_target_in_user_facing_names(self):
+        fitter = self._linked_fitter()
+        params = run_fit(fitter, 'bumps', 'amoeba')['parameters']
+        self.assertEqual(params['big_radius']['linked_to'], 'small_radius')
+        self.assertIsNone(params['small_radius']['linked_to'])
+        # The canonical A_/B_ spelling must never reach a user-facing string.
+        for info in params.values():
+            self.assertNotIn('A_', info['formatted'])
+            self.assertNotIn('B_', info['formatted'])
+
+    def test_radius_effective_tracks_radius_under_link_radius(self):
+        fitter = configure(
+            self.data_file,
+            structure_factor_name='hardsphere',
+            radius_effective_mode='link_radius',
+        )
+        with contextlib.redirect_stdout(io.StringIO()):
+            fitter.set_param('volfraction', value=0.2, min=0.0, max=0.6, vary=True)
+        params = run_fit(fitter, 'bumps', 'amoeba')['parameters']
+        self.assertEqual(params['radius_effective']['linked_to'], 'radius')
+        self.assertTrue(params['radius_effective']['fixed'])
+        self.assertEqual(params['radius_effective']['value'], params['radius']['value'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Fit result schema standardization:**

* Introduced the `build_result_parameters` function in `base.py` to assemble a unified, engine-independent `parameters` block for fit results. This ensures every model parameter (varied, fixed, or linked) is reported with the same five fields: `value`, `stderr`, `formatted`, `fixed`, and `linked_to`. Follower parameters now correctly report their target's fitted value and name the target in `linked_to` (`None` if unlinked).
* Updated the `bumps` and `scipy` fitting engines to use `build_result_parameters`, ensuring both engines report the same parameters and fields. 
* Adjusted the finalization step in `SANSFitter` to translate canonical parameter names and linked targets to user-facing aliases, so internal names (like `A_`/`B_`) never appear in user results.

**Documentation and interface improvements:**

* Updated the documentation and function docstrings to describe the new, consistent result schema, including the meaning of each field and the behavior for linked/fixed parameters. 
