### PR TITLE
Added truth-recovery and masked-data tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,6 @@ addopts = [
     "--tb=short",                  # Shorter traceback format
     "--strict-markers",            # Strict marker usage
     "-ra",                         # Show summary of all test outcomes
-    "--disable-warnings",          # Disable warnings display
 ]
 
 # Markers

--- a/src/sans_fitter/fitter.py
+++ b/src/sans_fitter/fitter.py
@@ -33,6 +33,7 @@ from .fitting import (
 )
 from .fitting.base import extract_fit_index, pd_is_active
 from .modeling.parameters import ParameterManager
+from .modeling.structure_factor import validate_radius_effective_mode
 from .plotting import DEFAULT_POSTERIOR_PREDICTIVE_DRAWS, plot_fit
 from .results import FitArtifacts, FitResultContract, PosteriorSummary, save_fit_result
 
@@ -580,7 +581,10 @@ class SANSFitter:
                 - 'link_radius': 'radius_effective' is constrained to the form factor's 'radius'.
 
         Raises:
-            ValueError: If no form factor model is set, or if the structure factor is invalid
+            ValueError: If no form factor model is set, or if the structure
+                factor name or radius_effective_mode is invalid. Every check
+                runs before any state is touched, so a rejected call leaves the
+                fitter exactly as it was.
         """
         if self.kernel is None or self.model_name is None:
             raise ValueError('No form factor model loaded. Use set_model() first.')
@@ -602,17 +606,26 @@ class SANSFitter:
                 f'Supported: {", ".join(supported_sf)}'
             )
 
+        # Validate the mode here, before anything is swapped. Leaving it to
+        # update_for_product_model would abort *after* self.kernel had become
+        # the product model while params still described the form factor — a
+        # desynchronized state in which the next fit silently evaluates the
+        # product kernel with default structure-factor parameters.
+        validate_radius_effective_mode(radius_effective_mode)
+
         # Create product model name
         full_model_name = f'{self.model_name}@{structure_factor_name}'
 
         try:
-            # Load the product model
-            self.kernel = load_model(full_model_name, dtype='single', platform='dll')
+            # Load the product model. Held locally until the parameter manager
+            # has accepted it, so a failure cannot desynchronize the two.
+            product_kernel = load_model(full_model_name, dtype='single', platform='dll')
 
             # Delegate parameter management to ParameterManager
             self._param_manager.update_for_product_model(
-                self.kernel, structure_factor_name, radius_effective_mode
+                product_kernel, structure_factor_name, radius_effective_mode
             )
+            self.kernel = product_kernel
 
             if radius_effective_mode == 'link_radius':
                 print("  Note: 'radius_effective' linked to 'radius' value")
@@ -634,12 +647,15 @@ class SANSFitter:
         if self._structure_factor_name is None:
             raise ValueError('No structure factor is currently set.')
 
-        # Reload the original form factor model
+        # Reload the original form factor model. Held locally until the
+        # parameter manager has restored its side, for the same reason as in
+        # set_structure_factor: kernel and params must never disagree.
         try:
-            self.kernel = load_model(self.model_name, dtype='single', platform='dll')
+            form_factor_kernel = load_model(self.model_name, dtype='single', platform='dll')
 
             # Delegate to ParameterManager - this restores params and PD state
             sf_name = self._param_manager.remove_structure_factor()
+            self.kernel = form_factor_kernel
 
             print(f"✓ Structure factor '{sf_name}' removed")
             print(f'  Reverted to form factor: {self.model_name}')

--- a/src/sans_fitter/fitting/scipy_engine.py
+++ b/src/sans_fitter/fitting/scipy_engine.py
@@ -14,6 +14,18 @@ try:
 except ImportError:
     SCIPY_AVAILABLE = False
 
+# Relative accuracy of the model curve. SANSFitter compiles sasmodels kernels
+# in single precision (``load_model(..., dtype='single')``), so two evaluations
+# agree to about 1e-7 and no further.
+KERNEL_PRECISION = float(np.finfo(np.float32).eps)
+# Forward-difference step for the numerical Jacobian, as a fraction of each
+# parameter. scipy defaults to sqrt(double eps) ~= 1.5e-8, which is *below* the
+# kernel's own resolution: the perturbed curve comes back bit-identical, the
+# Jacobian is exactly zero, and the optimizer stops at the starting point while
+# reporting success. Sizing the step to the kernel's precision instead makes
+# the derivative observable.
+JACOBIAN_STEP = float(np.sqrt(KERNEL_PRECISION))
+
 
 def fit_scipy(
     data: Any,
@@ -91,6 +103,9 @@ def fit_scipy(
     print(f'\nFitting with scipy.optimize (method: {method})...')
 
     if method == 'leastsq':
+        # epsfcn is the assumed relative error in the function; leastsq derives
+        # its step as sqrt(epsfcn)*x. See KERNEL_PRECISION.
+        kwargs.setdefault('epsfcn', KERNEL_PRECISION)
         result = leastsq(residual, x0, full_output=True, **kwargs)
         fitted_params = result[0]
         cov_matrix = result[1]
@@ -100,6 +115,8 @@ def fit_scipy(
             param_errors = np.zeros_like(fitted_params)
         chisq = np.sum(residual(fitted_params) ** 2)
     elif method == 'least_squares':
+        # diff_step is the relative step itself, not its square.
+        kwargs.setdefault('diff_step', JACOBIAN_STEP)
         result = least_squares(residual, x0, bounds=(bounds_lower, bounds_upper), **kwargs)
         fitted_params = result.x
         try:

--- a/src/sans_fitter/modeling/parameters.py
+++ b/src/sans_fitter/modeling/parameters.py
@@ -814,15 +814,18 @@ class ParameterManager:
         Raises:
             ValueError: If radius_effective_mode is invalid
         """
-        # Backup polydispersity state if not already done
-        if not self._backed_up_pd_state:
-            self.backup_pd_state()
-        self.params = self._sf_manager.apply(
+        # Build the new parameter set first: a rejected apply must not leave a
+        # polydispersity backup behind, which would later restore stale PD
+        # state on the next legitimate remove_structure_factor().
+        new_params = self._sf_manager.apply(
             kernel=kernel,
             sf_name=structure_factor_name,
             re_mode=radius_effective_mode,
             current_params=self.params,
         )
+        if not self._backed_up_pd_state:
+            self.backup_pd_state()
+        self.params = new_params
         self._prune_stale_links()
 
     def remove_structure_factor(self) -> str:

--- a/src/sans_fitter/modeling/structure_factor.py
+++ b/src/sans_fitter/modeling/structure_factor.py
@@ -25,6 +25,21 @@ def default_parameter_bounds(default: float, limits: tuple[float, float]) -> tup
     return lo, hi
 
 
+RADIUS_EFFECTIVE_MODES = ('unconstrained', 'link_radius')
+
+
+def validate_radius_effective_mode(mode: str) -> None:
+    """Raise for an unsupported ``radius_effective_mode``.
+
+    Exposed separately so callers can reject a bad mode *before* they start
+    swapping kernels and parameter sets.
+    """
+    if mode not in RADIUS_EFFECTIVE_MODES:
+        raise ValueError(
+            f"Invalid radius_effective_mode '{mode}'. Use 'unconstrained' or 'link_radius'."
+        )
+
+
 class StructureFactorManager:
     """Manage structure factor state and form-factor parameter backups."""
 
@@ -75,10 +90,7 @@ class StructureFactorManager:
         re_mode: str,
         current_params: dict[str, dict[str, Any]],
     ) -> dict[str, dict[str, Any]]:
-        if re_mode not in ['unconstrained', 'link_radius']:
-            raise ValueError(
-                f"Invalid radius_effective_mode '{re_mode}'. Use 'unconstrained' or 'link_radius'."
-            )
+        validate_radius_effective_mode(re_mode)
 
         if not self._form_factor_params:
             self.backup_params(current_params)

--- a/tests/test_truth_recovery.py
+++ b/tests/test_truth_recovery.py
@@ -1,0 +1,247 @@
+"""Behavioural tests the suite was missing (issue #21).
+
+The existing fitting tests assert only that a result dictionary has the
+expected keys, which cannot distinguish a converged fit from an optimizer that
+returned its starting point. These tests fit data generated from a known model
+and assert the parameters come back, on both engines, and that the surrounding
+machinery (masked rows, failed configuration) behaves.
+"""
+
+import contextlib
+import io
+import os
+import tempfile
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from sans_fitter import SANSFitter, examples
+
+ENGINES = [('bumps', 'amoeba'), ('lmfit', 'leastsq'), ('lmfit', 'least_squares')]
+
+# Parameters every case holds fixed, matching examples.simulate's defaults.
+FIXED = {'sld': 4.0, 'sld_solvent': 1.0, 'scale': 1.0, 'background': 0.001}
+
+CASES = [
+    ('sphere', {'radius': 50.0}, {'radius': 30.0}),
+    ('cylinder', {'radius': 20.0, 'length': 400.0}, {'radius': 12.0, 'length': 250.0}),
+]
+
+
+@contextlib.contextmanager
+def quiet():
+    """SANSFitter reports progress on stdout; tests do not need the wall of text."""
+    with contextlib.redirect_stdout(io.StringIO()):
+        yield
+
+
+def fit_truth_case(model, truth, start, engine, method, data=None, npoints=80):
+    """Fit simulated *model* data from *start* and return the result dict."""
+    if data is None:
+        data = examples.simulate(model, npoints=npoints, noise=0.02, seed=3, **truth, **FIXED)
+    with quiet():
+        fitter = SANSFitter()
+        fitter.set_data(data)
+        fitter.set_model(model)
+        for name, value in FIXED.items():
+            fitter.set_param(name, value=value, vary=False)
+        for name, value in start.items():
+            fitter.set_param(name, value=value, min=value / 10, max=value * 10, vary=True)
+        return fitter, fitter.fit(engine=engine, method=method)
+
+
+class TestTruthRecovery:
+    """Every engine must actually find the generating parameters."""
+
+    @pytest.mark.parametrize('engine,method', ENGINES)
+    @pytest.mark.parametrize('model,truth,start', CASES)
+    def test_parameters_are_recovered(self, model, truth, start, engine, method):
+        _fitter, result = fit_truth_case(model, truth, start, engine, method)
+        for name, expected in truth.items():
+            assert result['parameters'][name]['value'] == pytest.approx(expected, rel=0.05), name
+
+    @pytest.mark.parametrize('engine,method', ENGINES)
+    @pytest.mark.parametrize('model,truth,start', CASES)
+    def test_the_optimizer_moved_off_its_starting_point(self, model, truth, start, engine, method):
+        """A zero Jacobian makes an optimizer 'converge' where it began."""
+        _fitter, result = fit_truth_case(model, truth, start, engine, method)
+        for name, initial in start.items():
+            assert result['parameters'][name]['value'] != initial, name
+
+    @pytest.mark.parametrize('engine,method', ENGINES)
+    def test_uncertainties_are_finite_positive_and_cover_the_truth(self, engine, method):
+        model, truth, start = CASES[0]
+        _fitter, result = fit_truth_case(model, truth, start, engine, method)
+        info = result['parameters']['radius']
+        assert np.isfinite(info['stderr'])
+        assert info['stderr'] > 0
+        # Noise is 2%, so a stderr that lands the truth 5+ sigma away is not
+        # describing this fit.
+        assert abs(info['value'] - truth['radius']) < 5 * info['stderr']
+
+
+class TestCrossEngineAgreement:
+    """The same problem must give the same answer whichever engine runs it."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.model, cls.truth, cls.start = CASES[0]
+        cls.npoints = 80
+        cls.results = {
+            f'{engine}/{method}': fit_truth_case(
+                cls.model, cls.truth, cls.start, engine, method, npoints=cls.npoints
+            )[1]
+            for engine, method in ENGINES
+        }
+
+    def test_all_engines_agree_on_the_fitted_value(self):
+        values = [r['parameters']['radius']['value'] for r in self.results.values()]
+        for value in values[1:]:
+            assert value == pytest.approx(values[0], rel=1e-3)
+
+    def test_all_engines_agree_on_the_uncertainty(self):
+        errors = [r['parameters']['radius']['stderr'] for r in self.results.values()]
+        for stderr in errors[1:]:
+            assert stderr == pytest.approx(errors[0], rel=0.05)
+
+    def test_chisq_differs_only_by_the_degrees_of_freedom(self):
+        """Documents a known discrepancy rather than hiding it.
+
+        bumps normalizes chi-squared by the degrees of freedom; the scipy
+        engine stores the raw sum of squared residuals. Same fit, ~79x apart.
+        """
+        dof = self.npoints - 1  # one varying parameter
+        bumps = self.results['bumps/amoeba']['chisq']
+        scipy = self.results['lmfit/leastsq']['chisq']
+        assert scipy / dof == pytest.approx(bumps, rel=0.05)
+
+
+def data_with_nan_rows():
+    """Simulated data carrying NaN in I and in dI, which the loader masks out."""
+    data = examples.simulate('sphere', npoints=60, noise=0.02, seed=3, radius=50.0, **FIXED)
+    data.y[5] = np.nan
+    data.dy[11] = np.nan
+    return data
+
+
+class TestMaskedData:
+    """A single NaN row must not break fitting, plotting or export."""
+
+    N_MASKED = 2
+
+    @pytest.mark.parametrize('engine,method', ENGINES)
+    def test_truth_is_still_recovered(self, engine, method):
+        _fitter, result = fit_truth_case(
+            'sphere', {'radius': 50.0}, {'radius': 30.0}, engine, method, data=data_with_nan_rows()
+        )
+        assert result['parameters']['radius']['value'] == pytest.approx(50.0, rel=0.05)
+
+    @pytest.mark.parametrize('engine,method', ENGINES)
+    def test_the_fitted_curve_covers_the_unmasked_points(self, engine, method):
+        fitter, _result = fit_truth_case(
+            'sphere', {'radius': 50.0}, {'radius': 30.0}, engine, method, data=data_with_nan_rows()
+        )
+        curve = fitter._fit_contract.require_fitted_curve()
+        assert len(curve) == len(fitter.data.x) - self.N_MASKED
+        assert np.all(np.isfinite(curve))
+
+    @pytest.mark.parametrize('engine,method', ENGINES)
+    def test_plotting_and_export_survive_the_masked_rows(self, engine, method):
+        fitter, _result = fit_truth_case(
+            'sphere', {'radius': 50.0}, {'radius': 30.0}, engine, method, data=data_with_nan_rows()
+        )
+        with quiet():
+            figure = fitter.plot_results(show=False)
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = os.path.join(tmpdir, 'results.csv')
+                fitter.save_results(path)
+                with open(path) as handle:
+                    lines = handle.read().splitlines()
+
+        assert figure is not None
+        rows = [line for line in lines if line and not line.startswith(('#', 'Q,'))]
+        assert len(rows) == len(fitter.data.x) - self.N_MASKED
+        assert all('nan' not in row.lower() for row in rows)
+
+
+class TestStateAfterFailedStructureFactor:
+    """A rejected set_structure_factor must leave nothing half-applied."""
+
+    def build_fitter(self):
+        data = examples.simulate('sphere', npoints=60, noise=0.02, seed=3, radius=50.0, **FIXED)
+        with quiet():
+            fitter = SANSFitter()
+            fitter.set_data(data)
+            fitter.set_model('sphere')
+            fitter.set_param('radius', value=30.0, min=3.0, max=300.0, vary=True)
+        return fitter
+
+    @pytest.mark.parametrize(
+        'kwargs,message',
+        [
+            ({'radius_effective_mode': 'invalid_mode'}, 'Invalid radius_effective_mode'),
+            ({'structure_factor_name': 'not_a_structure_factor'}, 'Unsupported structure factor'),
+        ],
+    )
+    def test_rejected_call_changes_nothing(self, kwargs, message):
+        fitter = self.build_fitter()
+        before_params = {name: dict(info) for name, info in fitter.params.items()}
+        kwargs = {'structure_factor_name': 'hardsphere'} | kwargs
+
+        with pytest.raises(ValueError, match=message), quiet():
+            fitter.set_structure_factor(**kwargs)
+
+        assert fitter.model_name == 'sphere'
+        assert fitter.get_structure_factor() is None
+        assert fitter.params == before_params
+        assert 'radius_effective' not in fitter.params
+
+    def test_the_kernel_is_not_left_as_the_product_model(self):
+        """Otherwise the next fit silently evaluates the product kernel."""
+        fitter = self.build_fitter()
+        with pytest.raises(ValueError), quiet():
+            fitter.set_structure_factor('hardsphere', radius_effective_mode='invalid_mode')
+
+        with quiet():
+            after = fitter.fit(engine='bumps', method='amoeba')
+        reference = self.build_fitter()
+        with quiet():
+            expected = reference.fit(engine='bumps', method='amoeba')
+
+        assert after['chisq'] == pytest.approx(expected['chisq'], rel=1e-6)
+        assert after['parameters']['radius']['value'] == pytest.approx(
+            expected['parameters']['radius']['value'], rel=1e-6
+        )
+
+    def test_a_failed_removal_leaves_the_product_model_intact(self):
+        """The mirror case: kernel and params must not disagree either way."""
+        fitter = self.build_fitter()
+        with quiet():
+            fitter.set_structure_factor('hardsphere')
+        product_kernel = fitter.kernel
+        product_params = {name: dict(info) for name, info in fitter.params.items()}
+
+        with mock.patch.object(
+            fitter._param_manager, 'remove_structure_factor', side_effect=RuntimeError('boom')
+        ):
+            with pytest.raises(ValueError), quiet():
+                fitter.remove_structure_factor()
+
+        assert fitter.kernel is product_kernel
+        assert fitter.params == product_params
+        assert fitter.get_structure_factor() == 'hardsphere'
+
+    def test_a_later_legitimate_cycle_still_works(self):
+        fitter = self.build_fitter()
+        before_params = {name: dict(info) for name, info in fitter.params.items()}
+        with pytest.raises(ValueError), quiet():
+            fitter.set_structure_factor('hardsphere', radius_effective_mode='invalid_mode')
+
+        with quiet():
+            fitter.set_structure_factor('hardsphere')
+            assert 'radius_effective' in fitter.params
+            fitter.remove_structure_factor()
+
+        assert fitter.get_structure_factor() is None
+        assert fitter.params == before_params


### PR DESCRIPTION
This pull request introduces several important improvements to the fitting logic and robustness of the SANSFitter package, especially around structure factor handling, numerical stability in the scipy engine, and test coverage. The main themes are:
(1) preventing partial application of structure factors to avoid inconsistent internal state,
(2) improving numerical differentiation for fitting, and
(3) adding comprehensive behavioral tests to ensure correct optimizer behavior and state management.

**Robustness and Consistency Improvements:**

* The logic in `set_structure_factor` and `remove_structure_factor` in `fitter.py` was reworked to validate all inputs and build new kernels and parameter sets before updating any internal state. This prevents the fitter from being left in a partially-applied or desynchronized state if an error occurs 
* The validation of `radius_effective_mode` was centralized in a new function `validate_radius_effective_mode`, and is now called before any state changes, ensuring that invalid modes are rejected early
**Numerical Fitting Accuracy:**

* The scipy engine now uses kernel-precision-aware defaults for numerical differentiation (`epsfcn` and `diff_step`), ensuring that the optimizer can observe parameter changes despite single-precision kernel output. This fixes cases where the optimizer would falsely 'converge' at the starting point 

**Testing and Validation:**

* A new behavioral test suite (`tests/test_truth_recovery.py`) was added, covering parameter recovery, optimizer movement, uncertainty estimation, cross-engine agreement, handling of masked data, and robustness to failed structure factor operations. These tests ensure that the fitter behaves correctly in realistic scenarios and that failed operations do not leave the fitter in a broken state.

**Other changes:**

* The `--disable-warnings` option was removed from the pytest configuration, likely to ensure that warnings are visible during test runs.
